### PR TITLE
This will avoid the permission error when launching a container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,9 @@ RUN wget -O /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/
     chmod +x /usr/local/bin/dumb-init
 
 COPY docker-entrypoint.sh /docker-entrypoint.sh
+
+RUN chmod +x /docker-entrypoint.sh
+
 ENTRYPOINT ["/docker-entrypoint.sh"]
 
 EXPOSE 8000 8443 8001 7946


### PR DESCRIPTION
This is the error I'm trying to fix:

"container_linux.go:247: starting container process caused "exec: \"/docker-entrypoint.sh\": permission denied"