### PR TITLE
Disable local cache

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:3.6
-MAINTAINER Marco Palladino, marco@mashape.com
+LABEL maintainer Marco Palladino, marco@mashape.com
 
 ENV KONG_VERSION 0.11.1
 ENV KONG_SHA256 2291f92a935d850fe850394834c7737e99a82c37b0024637b4e17adfa1a4ef28

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -4,17 +4,15 @@ MAINTAINER Marco Palladino, marco@mashape.com
 ENV KONG_VERSION 0.11.1
 ENV KONG_SHA256 2291f92a935d850fe850394834c7737e99a82c37b0024637b4e17adfa1a4ef28
 
-RUN apk update \
-	&& apk add --virtual .build-deps wget tar ca-certificates \
-	&& apk add libgcc openssl pcre perl \
+RUN apk add --no-cache --virtual .build-deps wget tar ca-certificates \
+	&& apk add --no-cache libgcc openssl pcre perl \
 	&& wget -O kong.tar.gz "https://bintray.com/kong/kong-community-edition-alpine-tar/download_file?file_path=kong-community-edition-$KONG_VERSION.apk.tar.gz" \
 	&& echo "$KONG_SHA256 *kong.tar.gz" | sha256sum -c - \
 	&& tar -xzf kong.tar.gz -C /tmp \
 	&& rm -f kong.tar.gz \
 	&& cp -R /tmp/usr / \
 	&& rm -rf /tmp/usr \
-	&& apk del .build-deps \
-	&& rm -rf /var/cache/apk/*
+	&& apk del .build-deps
 
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -5,7 +5,7 @@ ENV KONG_VERSION 0.11.1
 ENV KONG_SHA256 2291f92a935d850fe850394834c7737e99a82c37b0024637b4e17adfa1a4ef28
 
 RUN apk add --no-cache --virtual .build-deps wget tar ca-certificates \
-	&& apk add --no-cache libgcc openssl pcre perl \
+	&& apk add --no-cache libgcc openssl pcre perl tzdata \
 	&& wget -O kong.tar.gz "https://bintray.com/kong/kong-community-edition-alpine-tar/download_file?file_path=kong-community-edition-$KONG_VERSION.apk.tar.gz" \
 	&& echo "$KONG_SHA256 *kong.tar.gz" | sha256sum -c - \
 	&& tar -xzf kong.tar.gz -C /tmp \


### PR DESCRIPTION
`apk` provides a handy `--no-cache` flag that [disables the global cache][1]. This is favored over `rm -rf /var/cache/apk/*`

Replaces the `MAINTAINER` instruction, which has been [deprecated][2], with a `LABEL`.

[1]: https://github.com/gliderlabs/docker-alpine/tree/master#usage
[2]: https://docs.docker.com/engine/reference/builder/#maintainer-deprecated