### PR TITLE
fix(centos) create 0.11.2 sha with proper rpm path

### DIFF
--- a/centos/Dockerfile
+++ b/centos/Dockerfile
@@ -1,7 +1,7 @@
 FROM centos:7
 MAINTAINER Marco Palladino, marco@mashape.com
 
-ENV KONG_VERSION 0.13.0rc1
+ENV KONG_VERSION 0.11.2
 
 RUN yum install -y wget https://bintray.com/kong/kong-community-edition-rpm/download_file?file_path=centos/7/kong-community-edition-$KONG_VERSION.el7.noarch.rpm && \
     yum clean all


### PR DESCRIPTION
The current 0.11.2 commit sha1
(2ed0fad88ed81623ea4afb2111033a9d87f3c03c) still uses the previous rpm
path (in ?file_path).

The purpose of this commit is to produce a new commit sha1 we can make
the 0.11 and 0.11.2 DockerHub tags point to.