### PR TITLE
Docker STOPSIGNAL: Use SIGQUIT instead of SIGTERM

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -21,6 +21,6 @@ ENTRYPOINT ["/docker-entrypoint.sh"]
 
 EXPOSE 8000 8443 8001 8444
 
-STOPSIGNAL SIGTERM
+STOPSIGNAL SIGQUIT
 
 CMD ["/usr/local/openresty/nginx/sbin/nginx", "-c", "/usr/local/kong/nginx.conf", "-p", "/usr/local/kong/"]

--- a/centos/Dockerfile
+++ b/centos/Dockerfile
@@ -11,6 +11,6 @@ ENTRYPOINT ["/docker-entrypoint.sh"]
 
 EXPOSE 8000 8443 8001 8444
 
-STOPSIGNAL SIGTERM
+STOPSIGNAL SIGQUIT
 
 CMD ["/usr/local/openresty/nginx/sbin/nginx", "-c", "/usr/local/kong/nginx.conf", "-p", "/usr/local/kong/"]


### PR DESCRIPTION
What:
-------

Kong container should stop Nginx with a SIGQUIT signal instead of SIGTERM.

Why:
------

From Nginx man page:
```
SIGINT, SIGTERM  Shut down quickly.
SIGQUIT          Shut down gracefully.
```

Use case:

We have 2 instances of Kong running in our environments and we want to upgrade them (either for a Kong upgrade, or just some configurations changes).

Our orchestrator will do a rolling upgrade, for that it will:
 * Stop sending requests to the first instance
 * docker stop this instance
 * Starting a new one
 * Sending traffic to this new instance
Then it will do the same for the second instance.

So with this process, we have no downtime on our API. But at the docker stop step, with a SIGTERM, Nginx will just cancel all active connections so we have some errors on the associated requests.

With a SIGQUIT, Nginx will stop process new requests but will let ending the actives ones, so we'll have no errors on APi calls.

