### PR TITLE
fix kong Dockerfile build was missing curl

### DIFF
--- a/compose/kong/Dockerfile
+++ b/compose/kong/Dockerfile
@@ -1,5 +1,8 @@
 FROM kong
 
+# make sure curl is installed
+RUN apk add --no-cache curl
+
 # get ContainerPilot release
 ENV CONTAINERPILOT_VERSION 2.7.2
 RUN export CP_SHA1=e886899467ced6d7c76027d58c7f7554c2fb2bcc \


### PR DESCRIPTION
Fixes #153
Fixes #151
 
Running `docker-compose up` would fail building kong Dockerfile because the kong image builds from Alpine which doesn't include curl.

So, one solution is to just install curl before attempting to use it.
