### PR TITLE
feat(alpine) use https repositories

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -4,7 +4,8 @@ LABEL maintainer Marco Palladino, marco@mashape.com
 ENV KONG_VERSION 0.13.1
 ENV KONG_SHA256 caf119ce7a367b9d9cd1ace55c4b6a499ff3c4693f80ea25129ebf2da0373fcc 
 
-RUN apk add --no-cache --virtual .build-deps wget tar ca-certificates \
+RUN sed -i 's/http\:\/\/dl-cdn.alpinelinux.org/https\:\/\/alpine.global.ssl.fastly.net/g' /etc/apk/repositories \
+	&& apk add --no-cache --virtual .build-deps wget tar ca-certificates \
 	&& apk add --no-cache libgcc openssl pcre perl tzdata curl \
 	&& wget -O kong.tar.gz "https://bintray.com/kong/kong-community-edition-alpine-tar/download_file?file_path=kong-community-edition-$KONG_VERSION.apk.tar.gz" \
 	&& echo "$KONG_SHA256 *kong.tar.gz" | sha256sum -c - \


### PR DESCRIPTION
## Summary

Use `https` in APK repositories.