### PR TITLE
fix: do not unconditionally set KONG_PREFIX env

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -23,4 +23,4 @@ EXPOSE 8000 8443 8001 8444
 
 STOPSIGNAL SIGTERM
 
-CMD ["/usr/local/openresty/nginx/sbin/nginx", "-c", "/usr/local/kong/nginx.conf", "-p", "/usr/local/kong/"]
+CMD ["kong", "start"]

--- a/alpine/docker-entrypoint.sh
+++ b/alpine/docker-entrypoint.sh
@@ -1,15 +1,14 @@
 #!/bin/sh
 set -e
 
-# Disabling nginx daemon mode
-export KONG_NGINX_DAEMON="off"
+if [[ "$1" == "kong" && "$2" =~ "start" ]]; then
+  export KONG_NGINX_DAEMON=off
+  PREFIX=${KONG_PREFIX:=/usr/local/kong}
 
-# Setting default prefix (override any existing variable)
-export KONG_PREFIX="/usr/local/kong"
-
-# Prepare Kong prefix
-if [ "$1" = "/usr/local/openresty/nginx/sbin/nginx" ]; then
-	kong prepare -p "/usr/local/kong"
+  kong prepare -p $PREFIX &&
+    exec /usr/local/openresty/nginx/sbin/nginx \
+      -p $PREFIX \
+      -c nginx.conf
 fi
 
 exec "$@"

--- a/centos/Dockerfile
+++ b/centos/Dockerfile
@@ -13,4 +13,4 @@ EXPOSE 8000 8443 8001 8444
 
 STOPSIGNAL SIGTERM
 
-CMD ["/usr/local/openresty/nginx/sbin/nginx", "-c", "/usr/local/kong/nginx.conf", "-p", "/usr/local/kong/"]
+CMD ["kong", "start"]

--- a/centos/docker-entrypoint.sh
+++ b/centos/docker-entrypoint.sh
@@ -1,15 +1,14 @@
 #!/bin/sh
 set -e
 
-# Disabling nginx daemon mode
-export KONG_NGINX_DAEMON="off"
+if [[ "$1" == "kong" && "$2" =~ "start" ]]; then
+  export KONG_NGINX_DAEMON=off
+  PREFIX=${KONG_PREFIX:=/usr/local/kong}
 
-# Setting default prefix (override any existing variable)
-export KONG_PREFIX="/usr/local/kong"
-
-# Prepare Kong prefix
-if [ "$1" = "/usr/local/openresty/nginx/sbin/nginx" ]; then
-	kong prepare -p "/usr/local/kong"
+  kong prepare -p $PREFIX &&
+    exec /usr/local/openresty/nginx/sbin/nginx \
+      -p $PREFIX \
+      -c nginx.conf
 fi
 
 exec "$@"


### PR DESCRIPTION
This PR fixes several flaws with the previous implementation:

* we do not unconditionally set KONG_PREFIX as an env variable
* we only set KONG_NGINX_DAEMON (to `off`) if we are starting Kong
  itself
* we use a safer way to determine whether or not we should prepare the
  prefix (only when `CMD` is `"kong (re)start"`)

It is now possible to use another prefix than `/usr/local/kong` within
the container (by specifying `-e KONG_PREFIX=`) which can be necessary
for specific container platforms (e.g. OpenShift).