### PR TITLE
fix(*) avoid using =~ in bourne shell

### DIFF
--- a/alpine/docker-entrypoint.sh
+++ b/alpine/docker-entrypoint.sh
@@ -1,14 +1,18 @@
 #!/bin/sh
 set -e
 
-if [[ "$1" == "kong" && "$2" =~ "start" ]]; then
-  export KONG_NGINX_DAEMON=off
+if [[ "$1" == "kong" ]]; then
   PREFIX=${KONG_PREFIX:=/usr/local/kong}
+  mkdir -p $PREFIX
 
-  kong prepare -p $PREFIX &&
+  if [[ "$2" == "start" || "$2" == "restart" ]]; then
+    export KONG_NGINX_DAEMON=off
+    kong prepare -p $PREFIX
+
     exec /usr/local/openresty/nginx/sbin/nginx \
       -p $PREFIX \
       -c nginx.conf
+  fi
 fi
 
 exec "$@"

--- a/centos/docker-entrypoint.sh
+++ b/centos/docker-entrypoint.sh
@@ -1,14 +1,18 @@
 #!/bin/sh
 set -e
 
-if [[ "$1" == "kong" && "$2" =~ "start" ]]; then
-  export KONG_NGINX_DAEMON=off
+if [[ "$1" == "kong" ]]; then
   PREFIX=${KONG_PREFIX:=/usr/local/kong}
+  mkdir -p $PREFIX
 
-  kong prepare -p $PREFIX &&
+  if [[ "$2" == "start" || "$2" == "restart" ]]; then
+    export KONG_NGINX_DAEMON=off
+    kong prepare -p $PREFIX
+
     exec /usr/local/openresty/nginx/sbin/nginx \
       -p $PREFIX \
       -c nginx.conf
+  fi
 fi
 
 exec "$@"


### PR DESCRIPTION
Instead, let's explicitely note that our branch should execute for both
`start` and `restart`.

This fix ensures that the CLI control commands behave the same way as a
host installation, with a few containerized-specific changes that is:

* `start` invokes `prepare` and guarantees `prepare` is called, and
spawns Nginx in the foreground.

* `restart` behaves the same as `start` when called while Kong is not
running. Calling `restart` on a running Kong container causes it to
terminate, which is expected behavior.

* `reload` on a running container respawn worker processes. If called on
a container not running Kong, it should not error out on non-existing
prefixes. The prefix is thus always created as per the `KONG_PREFIX` env
variable, or the `/usr/local/kong` default.

* `stop` behaves similarly as a non-containerized installation as well,
and should not error out on non-existing prefixes as well.

Another benefit of this fix is that the container does not show the "no
prefix at ..., trying to create it" notice message to stdout, thus
providing a less chatty experience to users.