### PR TITLE
Added support for OpenShift

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -14,7 +14,13 @@ RUN apk add --no-cache --virtual .build-deps wget tar ca-certificates \
 	&& rm -rf /tmp/usr \
 	&& cp -R /tmp/etc / \
 	&& rm -rf /tmp/etc \
-	&& apk del .build-deps
+	&& apk del .build-deps \
+	# OpenShift specific. OpenShift runs containers using an arbitrarily assigned user ID.
+	# This user doesn't have access to change file permissions during runtime, they have to be changed during image building.
+	# https://docs.okd.io/latest/creating_images/guidelines.html#use-uid
+	&& mkdir -p "/usr/local/kong" \
+	&& chgrp -R 0 "/usr/local/kong" \
+	&& chmod -R g=u "/usr/local/kong"
 
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/centos/Dockerfile
+++ b/centos/Dockerfile
@@ -4,7 +4,13 @@ LABEL maintainer="Kong Core Team <team-core@konghq.com>"
 ENV KONG_VERSION 1.0.0rc2
 
 RUN yum install -y wget https://bintray.com/kong/kong-community-edition-rpm/download_file?file_path=centos/7/kong-community-edition-$KONG_VERSION.el7.noarch.rpm && \
-    yum clean all
+    yum clean all && \
+    # OpenShift specific. OpenShift runs containers using an arbitrarily assigned user ID.
+    # This user doesn't have access to change file permissions during runtime, they have to be changed during image building.
+    # https://docs.okd.io/latest/creating_images/guidelines.html#use-uid
+    mkdir -p "/usr/local/kong" && \
+    chgrp -R 0 "/usr/local/kong" && \
+    chmod -R g=u "/usr/local/kong"
 
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/legacy/Dockerfile
+++ b/legacy/Dockerfile
@@ -4,7 +4,13 @@ MAINTAINER Marco Palladino, marco@mashape.com
 ENV KONG_VERSION 0.10.4
 
 RUN yum install -y wget https://bintray.com/kong/kong-community-edition-rpm/download_file?file_path=dists%2Fkong-community-edition-$KONG_VERSION.el7.noarch.rpm && \
-    yum clean all
+    yum clean all && \
+    # OpenShift specific. OpenShift runs containers using an arbitrarily assigned user ID.
+    # This user doesn't have access to change file permissions during runtime, they have to be changed during image building.
+    # https://docs.okd.io/latest/creating_images/guidelines.html#use-uid
+    mkdir -p "/usr/local/kong" && \
+    chgrp -R 0 "/usr/local/kong" && \
+    chmod -R g=u "/usr/local/kong"
 
 RUN wget -O /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.1.3/dumb-init_1.1.3_amd64 && \
     chmod +x /usr/local/bin/dumb-init

--- a/rhel/Dockerfile
+++ b/rhel/Dockerfile
@@ -15,7 +15,13 @@ LABEL name="Kong" \
 COPY LICENSE /licenses/
 
 RUN yum install -y wget https://bintray.com/kong/kong-community-edition-rpm/download_file?file_path=rhel/7/kong-community-edition-$KONG_VERSION.rhel7.noarch.rpm && \
-    yum clean all
+    yum clean all && \
+    # OpenShift specific. OpenShift runs containers using an arbitrarily assigned user ID.
+    # This user doesn't have access to change file permissions during runtime, they have to be changed during image building.
+    # https://docs.okd.io/latest/creating_images/guidelines.html#use-uid
+    mkdir -p "/usr/local/kong" && \
+    chgrp -R 0 "/usr/local/kong" && \
+    chmod -R g=u "/usr/local/kong"
 
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 


### PR DESCRIPTION
From OpenShift [docs](https://docs.openshift.org/3.9/creating_images/guidelines.html#use-uid):

> By default, OpenShift Origin runs containers using an arbitrarily assigned user ID. This provides additional security against processes escaping the container due to a container engine vulnerability and thereby achieving escalated permissions on the host node.

I've added small changes, so Kong could be run on OpenShift out of box.

Please also add those changes to Enterprise version.