### PR TITLE
Update year in license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2016-2017 Kong Inc.
+   Copyright 2016-2018 Kong Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
The year in license was 2016-2017 previously. I've changed it to 2016-2018
It is to ensure that no copyright issues arise 