### PR TITLE
fix(compose) use kong user for pg healthcheck

### DIFF
--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -49,7 +49,7 @@ services:
       - POSTGRES_USER=kong
       - POSTGRES_DB=kong
     healthcheck:
-      test: ["CMD", "pg_isready", "-U", "postgres"]
+      test: ["CMD", "pg_isready", "-U", "kong"]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
Use the `kong` user for Postgres healthchecks instead of `postgres`. An [upstream fix to the Postgres image](https://github.com/docker-library/postgres/commit/3f585c58df93e93b730c09a13e8904b96fa20c58) removes the default `postgres` user if another user is specified.

Fix #180
Fix #179
Fix #174