### PR TITLE
set the default PG_USER in .env

### DIFF
--- a/compose/.env
+++ b/compose/.env
@@ -1,0 +1,1 @@
+PG_USER=kong

--- a/compose/.env
+++ b/compose/.env
@@ -1,1 +1,0 @@
-PG_USER=kong

--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -3,10 +3,10 @@ services:
   kong-database:
     image: postgres:9.5
     environment:
-      - POSTGRES_USER=${PG_USER}
+      - POSTGRES_USER=${PG_USER:-kong}
       - POSTGRES_DB=kong
     healthcheck:
-      test: ["CMD", "pg_isready", "-U", "${PG_USER}"]
+      test: ["CMD", "pg_isready", "-U", "${PG_USER:-kong}"]
       interval: 30s
       timeout: 30s
       retries: 3
@@ -21,6 +21,7 @@ services:
       - KONG_DATABASE=postgres
       - KONG_PG_HOST=kong-database
       - KONG_PG_DATABASE=kong
+      - KONG_PG_USER=${PG_USER:-kong}
       - KONG_ADMIN_LISTEN=0.0.0.0:8001        
     ports:
       - "8000:8000"

--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -3,10 +3,10 @@ services:
   kong-database:
     image: postgres:9.5
     environment:
-      - POSTGRES_USER=kong
+      - POSTGRES_USER=${PG_USER}
       - POSTGRES_DB=kong
     healthcheck:
-      test: ["CMD", "pg_isready", "-U", "postgres"]
+      test: ["CMD", "pg_isready", "-U", "${PG_USER}"]
       interval: 30s
       timeout: 30s
       retries: 3


### PR DESCRIPTION
Inspired by https://github.com/Kong/docker-kong/pull/187/files set a sensible default for the postgres user which can be overridden by exporting `PG_USER` as an environment variable