### PR TITLE
Pass arguments to 'kong prepare' in docker-entrypoint.sh

### DIFF
--- a/alpine/docker-entrypoint.sh
+++ b/alpine/docker-entrypoint.sh
@@ -11,7 +11,8 @@ if [[ "$1" == "kong" ]]; then
   PREFIX=${KONG_PREFIX:=/usr/local/kong}
 
   if [[ "$2" == "docker-start" ]]; then
-    kong prepare -p "$PREFIX"
+    shift 2
+    kong prepare -p "$PREFIX" $@
     chown -R kong "$PREFIX"
 
     # workaround for https://github.com/moby/moby/issues/31243

--- a/centos/docker-entrypoint.sh
+++ b/centos/docker-entrypoint.sh
@@ -11,7 +11,8 @@ if [[ "$1" == "kong" ]]; then
   PREFIX=${KONG_PREFIX:=/usr/local/kong}
 
   if [[ "$2" == "docker-start" ]]; then
-    kong prepare -p "$PREFIX"
+    shift 2
+    kong prepare -p "$PREFIX" $@
     chown -R kong "$PREFIX"
 
     # workaround for https://github.com/moby/moby/issues/31243

--- a/rhel/docker-entrypoint.sh
+++ b/rhel/docker-entrypoint.sh
@@ -8,7 +8,8 @@ if [[ "$1" == "kong" ]]; then
   mkdir -p $PREFIX
 
   if [[ "$2" == "docker-start" ]]; then
-    kong prepare -p $PREFIX
+    shift 2
+    kong prepare -p $PREFIX $@
 
     exec /usr/local/openresty/nginx/sbin/nginx \
       -p $PREFIX \


### PR DESCRIPTION
The idea here is to allow additional arguments to pass through to the `kong prepare` command in the entrypoint script without fundamentally changing how the container operates normally.  This way, one could supply flags for verbose/debug output, or a custom nginx template (As is the case for Issue #181 )

I've tested this with the alpine container, but I imagine there wouldn't be any issues with this change for centos/rhel either.