### PR TITLE
feat(exit) add script for graceful exit

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -17,6 +17,7 @@ RUN apk add --no-cache --virtual .build-deps wget tar ca-certificates \
 	&& apk del .build-deps
 
 COPY docker-entrypoint.sh /docker-entrypoint.sh
+COPY graceful-exit.sh /graceful-exit.sh
 ENTRYPOINT ["/docker-entrypoint.sh"]
 
 EXPOSE 8000 8443 8001 8444

--- a/alpine/graceful-exit.sh
+++ b/alpine/graceful-exit.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# wait for orchestration tools to become consistent
+if [[ "$1" == "" ]]; then
+  sleep 3
+else
+  sleep $1
+fi
+
+# gracefully exit Kong with a timeout
+if [[ "$2" == "" ]]; then
+  kong quit
+else
+  kong quit --timeout=$2
+fi


### PR DESCRIPTION
This adds a script to do a graceful exit. It takes 2 parameters, pre-timeout and post-timeout.

TLDR:

 - pre-timeout allows to drain NEW connections coming in
 - post-timeout allows to drain ACTIVE connections to completion

The pre-timeout (default 3 seconds) is the wait period before the actual exit is executed. This is useful for orchestration tools (👀 at you k8s!), that are eventually consistent in their updates. Without the wait period, Kong will stop accepting new connections before the loadbalancers and other components are updated and actually stop sending new connections, which causes lost connections.

The post-timeout is the standard timeout used for the `kong quit` command.

So using this script in Kubernetes allows to set a PreStop hook:
```yaml
            preStop:
              exec:
                command: ["/graceful-exit.sh", [3], [10]]
```

NOTE: untested, for discussion only (also needs updates to the others if accepted)