### PR TITLE
chore(*) bump to Kong 0.15.0

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,8 +1,8 @@
 FROM alpine:3.6
 LABEL maintainer="Kong Core Team <team-core@konghq.com>"
 
-ENV KONG_VERSION 1.0.0
-ENV KONG_SHA256 79001d96c28d774bcf868f281e8e3486c4027ed35d69da6560172a742240b862
+ENV KONG_VERSION 0.15.0
+ENV KONG_SHA256 f2adc4e40a4a33c657955d6d9ec034d80827f915bb9fe8c2ac2a36aed7edf13b
 
 RUN adduser -Su 1337 kong \
 	&& mkdir -p "/usr/local/kong" \

--- a/centos/Dockerfile
+++ b/centos/Dockerfile
@@ -1,7 +1,7 @@
 FROM centos:7
 LABEL maintainer="Kong Core Team <team-core@konghq.com>"
 
-ENV KONG_VERSION 1.0.0
+ENV KONG_VERSION 0.15.0
 
 RUN useradd --uid 1337 kong \
     && yum install -y https://bintray.com/kong/kong-community-edition-rpm/download_file?file_path=centos/7/kong-community-edition-$KONG_VERSION.el7.noarch.rpm \

--- a/rhel/Dockerfile
+++ b/rhel/Dockerfile
@@ -2,7 +2,7 @@ FROM registry.access.redhat.com/rhel7
 
 MAINTAINER Kong
 
-ENV KONG_VERSION 1.0.0
+ENV KONG_VERSION 0.15.0
 
 LABEL name="Kong" \
       vendor="Kong" \


### PR DESCRIPTION
this change makes the assumption that when someone clones master of this repository they want to build 0.15.0