### PR TITLE
Fix kong migrations command

### DIFF
--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2.1'
 services:
   kong-migrations:
     image: "${KONG_DOCKER_TAG:-kong:latest}"
-    command: kong migrations bootstrap
+    command: kong migrations up
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
The `kong migrations bootstrap` doesn't work anymore. Update the command to `kong migrations up`.