### PR TITLE
fix(centos) centos doesn't have su-exec

### DIFF
--- a/centos/Dockerfile
+++ b/centos/Dockerfile
@@ -3,6 +3,18 @@ LABEL maintainer="Kong Core Team <team-core@konghq.com>"
 
 ENV KONG_VERSION 0.15.0
 
+ARG SU_EXEC_VERSION=0.2
+ARG SU_EXEC_URL="https://github.com/ncopa/su-exec/archive/v${SU_EXEC_VERSION}.tar.gz"
+
+RUN yum install -y -q gcc make \
+&& curl -sL "${SU_EXEC_URL}" | tar -C /tmp -zxf - \ 
+ && make -C "/tmp/su-exec-${SU_EXEC_VERSION}" \
+&& cp "/tmp/su-exec-${SU_EXEC_VERSION}/su-exec" /usr/bin \
+&& rm -fr "/tmp/su-exec-${SU_EXEC_VERSION}" \
+&& yum autoremove -y -q gcc make \
+&& yum clean all -q \
+&& rm -fr /var/cache/yum/* /tmp/yum_save*.yumtx /root/.pki
+
 RUN useradd --uid 1337 kong \
     && yum install -y https://bintray.com/kong/kong-community-edition-rpm/download_file?file_path=centos/7/kong-community-edition-$KONG_VERSION.el7.noarch.rpm \
     && yum clean all

--- a/centos/Dockerfile
+++ b/centos/Dockerfile
@@ -8,7 +8,7 @@ ARG SU_EXEC_URL="https://github.com/ncopa/su-exec/archive/v${SU_EXEC_VERSION}.ta
 
 RUN yum install -y -q gcc make \
 && curl -sL "${SU_EXEC_URL}" | tar -C /tmp -zxf - \ 
- && make -C "/tmp/su-exec-${SU_EXEC_VERSION}" \
+&& make -C "/tmp/su-exec-${SU_EXEC_VERSION}" \
 && cp "/tmp/su-exec-${SU_EXEC_VERSION}/su-exec" /usr/bin \
 && rm -fr "/tmp/su-exec-${SU_EXEC_VERSION}" \
 && yum autoremove -y -q gcc make \

--- a/centos/docker-entrypoint.sh
+++ b/centos/docker-entrypoint.sh
@@ -26,7 +26,7 @@ if [[ "$1" == "kong" ]]; then
       setcap cap_net_raw=+ep /usr/local/openresty/nginx/sbin/nginx
     fi
 
-    su-exec kong /usr/local/openresty/nginx/sbin/nginx \
+    exec su-exec kong /usr/local/openresty/nginx/sbin/nginx \
       -p "$PREFIX" \
       -c nginx.conf
   fi

--- a/centos/docker-entrypoint.sh
+++ b/centos/docker-entrypoint.sh
@@ -26,9 +26,9 @@ if [[ "$1" == "kong" ]]; then
       setcap cap_net_raw=+ep /usr/local/openresty/nginx/sbin/nginx
     fi
 
-    exec su-exec kong /usr/local/openresty/nginx/sbin/nginx \
-      -p "$PREFIX" \
-      -c nginx.conf
+    su -c "exec /usr/local/openresty/nginx/sbin/nginx \
+      -p '$PREFIX' \
+      -c nginx.conf" kong
   fi
 fi
 

--- a/centos/docker-entrypoint.sh
+++ b/centos/docker-entrypoint.sh
@@ -26,9 +26,9 @@ if [[ "$1" == "kong" ]]; then
       setcap cap_net_raw=+ep /usr/local/openresty/nginx/sbin/nginx
     fi
 
-    su -c "exec /usr/local/openresty/nginx/sbin/nginx \
-      -p '$PREFIX' \
-      -c nginx.conf" kong
+    su-exec kong /usr/local/openresty/nginx/sbin/nginx \
+      -p "$PREFIX" \
+      -c nginx.conf
   fi
 fi
 


### PR DESCRIPTION
Tested locally:
```
docker build --no-cache -t kong:centosfix .
export KONG_DOCKER_TAG=kong:centosfix
cd ../compose
docker-compose up -d
docker-compose logs kong

docker-compose exec kong ps aux
USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
kong         1  1.0  0.2 266504 18740 ?        Ss   18:15   0:00 nginx: master p
kong        37  0.0  0.4 285084 33700 ?        S    18:15   0:00 nginx: worker p
kong        38  0.0  0.4 285084 33548 ?        S    18:15   0:00 nginx: worker p
root        39  0.0  0.0  51752  3484 ?        Rs+  18:16   0:00 ps aux
```

Manual Test Steps:

- [x] Image builds
- [x] Works in docker-compose
- [x] NGINX master process is PID 1
- [x] NGINX master process is ran by `kong` not `root`
- [x] Works in k8s with transparent proxying