### PR TITLE
chore(*) bump to Kong 1.0.1

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,8 +1,8 @@
 FROM alpine:3.6
 LABEL maintainer="Kong Core Team <team-core@konghq.com>"
 
-ENV KONG_VERSION 0.15.0
-ENV KONG_SHA256 f2adc4e40a4a33c657955d6d9ec034d80827f915bb9fe8c2ac2a36aed7edf13b
+ENV KONG_VERSION 1.0.1
+ENV KONG_SHA256 4c394b73ece3f83bf67a71240cad6b3a225d621757b04cd1ea8cd45aa8469813
 
 RUN adduser -Su 1337 kong \
 	&& mkdir -p "/usr/local/kong" \

--- a/centos/Dockerfile
+++ b/centos/Dockerfile
@@ -1,7 +1,7 @@
 FROM centos:7
 LABEL maintainer="Kong Core Team <team-core@konghq.com>"
 
-ENV KONG_VERSION 0.15.0
+ENV KONG_VERSION 1.0.1
 
 ARG SU_EXEC_VERSION=0.2
 ARG SU_EXEC_URL="https://github.com/ncopa/su-exec/archive/v${SU_EXEC_VERSION}.tar.gz"


### PR DESCRIPTION
Manual Test Steps:

- [x] Image builds
- [x] Works in docker-compose
- [x] NGINX master process is PID 1
- [x] NGINX master process is ran by kong not root
- [ ] Works in k8s with transparent proxying