### PR TITLE
fix(luarocks) makes LuaRocks usable within the images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,5 @@ script:
       echo "\tVersion built is $version_built";
       exit 1;
     fi
+  - docker run -ti kong-$BASE luarocks install version
   - popd

--- a/centos/Dockerfile
+++ b/centos/Dockerfile
@@ -6,7 +6,7 @@ ENV KONG_VERSION 1.0.2
 ARG SU_EXEC_VERSION=0.2
 ARG SU_EXEC_URL="https://github.com/ncopa/su-exec/archive/v${SU_EXEC_VERSION}.tar.gz"
 
-RUN yum install -y -q gcc make \
+RUN yum install -y -q gcc make unzip \
 && curl -sL "${SU_EXEC_URL}" | tar -C /tmp -zxf - \
 && make -C "/tmp/su-exec-${SU_EXEC_VERSION}" \
 && cp "/tmp/su-exec-${SU_EXEC_VERSION}/su-exec" /usr/bin \


### PR DESCRIPTION
Currently CentOS image is unable to install rocks.

The goal is not to make LR fully functional, just enough such that it can install a packed rock.