### PR TITLE
Allow running as non-root

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -6,6 +6,7 @@ ENV KONG_SHA256 72abd186181b5ebb263c4e12db5d89cac529e2b5ca858015d44a34d560755b35
 
 RUN adduser -Su 1337 kong \
 	&& mkdir -p "/usr/local/kong" \
+	&& chown -R kong "/usr/local/kong" \
 	&& apk add --no-cache --virtual .build-deps wget tar ca-certificates \
 	&& apk add --no-cache libgcc openssl pcre perl tzdata curl libcap su-exec \
 	&& wget -O kong.tar.gz "https://bintray.com/kong/kong-community-edition-alpine-tar/download_file?file_path=kong-community-edition-$KONG_VERSION.apk.tar.gz" \
@@ -25,5 +26,7 @@ ENTRYPOINT ["/docker-entrypoint.sh"]
 EXPOSE 8000 8443 8001 8444
 
 STOPSIGNAL SIGTERM
+
+USER kong
 
 CMD ["kong", "docker-start"]

--- a/alpine/docker-entrypoint.sh
+++ b/alpine/docker-entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-set -e
+set -ex
 
 export KONG_NGINX_DAEMON=off
 
@@ -27,7 +27,7 @@ if [[ "$1" == "kong" ]]; then
       setcap cap_net_raw=+ep /usr/local/openresty/nginx/sbin/nginx
     fi
 
-    exec su-exec kong /usr/local/openresty/nginx/sbin/nginx \
+    /usr/local/openresty/nginx/sbin/nginx \
       -p "$PREFIX" \
       -c nginx.conf
   fi

--- a/centos/Dockerfile
+++ b/centos/Dockerfile
@@ -3,21 +3,11 @@ LABEL maintainer="Kong Core Team <team-core@konghq.com>"
 
 ENV KONG_VERSION 1.1.0rc1
 
-ARG SU_EXEC_VERSION=0.2
-ARG SU_EXEC_URL="https://github.com/ncopa/su-exec/archive/v${SU_EXEC_VERSION}.tar.gz"
-
-RUN yum install -y -q gcc make unzip \
-&& curl -sL "${SU_EXEC_URL}" | tar -C /tmp -zxf - \
-&& make -C "/tmp/su-exec-${SU_EXEC_VERSION}" \
-&& cp "/tmp/su-exec-${SU_EXEC_VERSION}/su-exec" /usr/bin \
-&& rm -fr "/tmp/su-exec-${SU_EXEC_VERSION}" \
-&& yum autoremove -y -q gcc make \
-&& yum clean all -q \
-&& rm -fr /var/cache/yum/* /tmp/yum_save*.yumtx /root/.pki
-
 RUN useradd --uid 1337 kong \
-    && yum install -y https://bintray.com/kong/kong-community-edition-rpm/download_file?file_path=centos/7/kong-community-edition-$KONG_VERSION.el7.noarch.rpm \
-    && yum clean all
+  && yum install -y https://bintray.com/kong/kong-community-edition-rpm/download_file?file_path=centos/7/kong-community-edition-$KONG_VERSION.el7.noarch.rpm \
+  && yum clean all \
+  && mkdir -p "/usr/local/kong" \
+  && chown -R kong "/usr/local/kong"
 
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 
@@ -26,5 +16,7 @@ ENTRYPOINT ["/docker-entrypoint.sh"]
 EXPOSE 8000 8443 8001 8444
 
 STOPSIGNAL SIGTERM
+
+USER kong
 
 CMD ["kong", "docker-start"]

--- a/centos/docker-entrypoint.sh
+++ b/centos/docker-entrypoint.sh
@@ -27,7 +27,7 @@ if [[ "$1" == "kong" ]]; then
       setcap cap_net_raw=+ep /usr/local/openresty/nginx/sbin/nginx
     fi
 
-    exec su-exec kong /usr/local/openresty/nginx/sbin/nginx \
+    /usr/local/openresty/nginx/sbin/nginx \
       -p "$PREFIX" \
       -c nginx.conf
   fi


### PR DESCRIPTION
`su-exec` needs to run as root so as long as the `entrypoint` script uses it users cannot run the container as a non-root user.

This patch allows the user to set the `KONG_DO_NOT_SU_EXEC` flag to avoid running `su-exec` and allowing kong to be executed.

I'm running this on Kubernetes, mounting the `KONG_PREFIX` directory as an `emptyDir` and configuring Kong to run as `kong` user and mount `KONG_PREFIX` with `kong`'s GID:

```
      securityContext:
        fsGroup: 65533
        runAsUser: 1337
```