### PR TITLE
OpenShift deployment with anyuid / arbitrary user and raw TCP

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -17,6 +17,7 @@ RUN adduser -Su 1337 -g root kong  \
 	&& cp -R /tmp/etc / \
 	&& rm -rf /tmp/etc \
 	&& apk del .build-deps \
+	&& chown -R kong /usr/local/kong \
 	&& chgrp -R 0 /usr/local/kong \
 	&& chmod -R g=u /usr/local/kong
 

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -21,6 +21,13 @@ RUN adduser -Su 1337 -g root kong  \
 	&& chgrp -R 0 /usr/local/kong \
 	&& chmod -R g=u /usr/local/kong
 
+# for transparent proxy usage enable setcup for kong
+RUN chown kong /usr/local/openresty/nginx/sbin/ \
+	&& cp /usr/local/openresty/nginx/sbin/nginx /usr/local/openresty/nginx/sbin/nginx-transparent \
+	&& cp /usr/local/openresty/nginx/sbin/nginx /usr/local/openresty/nginx/sbin/nginx-non-transparent \
+	&& rm /usr/local/openresty/nginx/sbin/nginx \
+    && setcap cap_net_raw=+ep /usr/local/openresty/nginx/sbin/nginx-transparent
+
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 
 USER kong

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -16,9 +16,13 @@ RUN adduser -Su 1337 kong \
 	&& rm -rf /tmp/usr \
 	&& cp -R /tmp/etc / \
 	&& rm -rf /tmp/etc \
-	&& apk del .build-deps
+	&& apk del .build-deps \
+	&& chgrp -R 0 /usr/local/kong \
+	&& chmod -R g=u /usr/local/kong
 
 COPY docker-entrypoint.sh /docker-entrypoint.sh
+
+USER kong
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="Kong Core Team <team-core@konghq.com>"
 ENV KONG_VERSION 1.1.0rc1
 ENV KONG_SHA256 72abd186181b5ebb263c4e12db5d89cac529e2b5ca858015d44a34d560755b35
 
-RUN adduser -Su 1337 kong \
+RUN adduser -Su 1337 -g root kong  \
 	&& mkdir -p "/usr/local/kong" \
 	&& apk add --no-cache --virtual .build-deps wget tar ca-certificates \
 	&& apk add --no-cache libgcc openssl pcre perl tzdata curl libcap su-exec \

--- a/alpine/docker-entrypoint.sh
+++ b/alpine/docker-entrypoint.sh
@@ -13,11 +13,6 @@ if [[ "$1" == "kong" ]]; then
   if [[ "$2" == "docker-start" ]]; then
     shift 2
     kong prepare -p "$PREFIX" "$@"
-    chown -R kong "$PREFIX"
-
-    # workaround for https://github.com/moby/moby/issues/31243
-    chmod o+w /proc/self/fd/1
-    chmod o+w /proc/self/fd/2
 
     if [ ! -z ${SET_CAP_NET_RAW} ] \
         || has_transparent "$KONG_STREAM_LISTEN" \
@@ -27,7 +22,7 @@ if [[ "$1" == "kong" ]]; then
       setcap cap_net_raw=+ep /usr/local/openresty/nginx/sbin/nginx
     fi
 
-    exec su-exec kong /usr/local/openresty/nginx/sbin/nginx \
+    /usr/local/openresty/nginx/sbin/nginx \
       -p "$PREFIX" \
       -c nginx.conf
   fi


### PR DESCRIPTION
This pull request is an update to pull request #233 (see also a copy of the notes below)
For the use case that Kong needs to run in raw tcp mode I have added some more code - it does work on my test environment but maybe it does not look very elegant.

1. I create within the Dockerfile (while still being root) two copies of Nginx, one with setcap run against it, one without
2. In docker-entrypoint I create a link to either the setcap ("transparent") version of Nginx or the non-setcap one depending on startup variables
3. kong prepare is now after the check for raw tcp as we need to create the Nginx link first

So when raw tcp is needed the Nginx executable has the needed permissions for raw tcp.

Oh, and I have readded the "exec" again but without the su-exec as we are not root

*** from #233 
This pull request changes the Dockerfile and entrypoint.sh in a way that the image can be run without root privileges and as an arbitrary user (anyuid). When those changes have been applied Kong can be run on a default OpenShift installation without changing any default settings regarding root user or arbitrary user.

See https://docs.openshift.com/enterprise/3.0/creating_images/guidelines.html for reference about the needed changes.

The Dockerfile changes in detail:

kong user is now member of the root group
the chown command which has been located in the entrypoint.sh until now is part of the Dockerfile (as we only have the permissions here to execute the command)
chgrp/chmod commands added so /usr/local/kong belongs to user kong's root group
USER kong added so image is run as kong from the start
The entrypoint.sh changes in detail:

chown and chgrp commands removed / relocated to Dockerfile (we are user kong in entrypoint.sh now so no permissions to do so anymore)
"exec su-exec kong" removed as we are king anyway