### PR TITLE
chore(*) bump Kong to 1.1.0

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,8 +1,8 @@
 FROM alpine:3.6
 LABEL maintainer="Kong Core Team <team-core@konghq.com>"
 
-ENV KONG_VERSION 1.1.0rc1
-ENV KONG_SHA256 72abd186181b5ebb263c4e12db5d89cac529e2b5ca858015d44a34d560755b35
+ENV KONG_VERSION 1.1.0
+ENV KONG_SHA256 51a8aea79d5e074c84fabd73ecaf45ee9060ad8269c2aa0bcb267b73ec6f9231
 
 RUN adduser -Su 1337 kong \
 	&& mkdir -p "/usr/local/kong" \

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -8,7 +8,7 @@ RUN adduser -Su 1337 kong \
 	&& mkdir -p "/usr/local/kong" \
 	&& apk add --no-cache --virtual .build-deps wget tar ca-certificates \
 	&& apk add --no-cache libgcc openssl pcre perl tzdata curl libcap su-exec \
-	&& wget -O kong.tar.gz "https://bintray.com/kong/kong-community-edition-alpine-tar/download_file?file_path=kong-community-edition-$KONG_VERSION.apk.tar.gz" \
+	&& wget -O kong.tar.gz "https://bintray.com/kong/kong-alpine-tar/download_file?file_path=kong-$KONG_VERSION.apk.tar.gz" \
 	&& echo "$KONG_SHA256 *kong.tar.gz" | sha256sum -c - \
 	&& tar -xzf kong.tar.gz -C /tmp \
 	&& rm -f kong.tar.gz \

--- a/centos/Dockerfile
+++ b/centos/Dockerfile
@@ -16,7 +16,7 @@ RUN yum install -y -q gcc make unzip \
 && rm -fr /var/cache/yum/* /tmp/yum_save*.yumtx /root/.pki
 
 RUN useradd --uid 1337 kong \
-    && yum install -y https://bintray.com/kong/kong-community-edition-rpm/download_file?file_path=centos/7/kong-community-edition-$KONG_VERSION.el7.noarch.rpm \
+    && yum install -y https://bintray.com/kong/kong-rpm/download_file?file_path=kong-$KONG_VERSION.el7.noarch.rpm \
     && yum clean all
 
 COPY docker-entrypoint.sh /docker-entrypoint.sh

--- a/centos/Dockerfile
+++ b/centos/Dockerfile
@@ -1,7 +1,7 @@
 FROM centos:7
 LABEL maintainer="Kong Core Team <team-core@konghq.com>"
 
-ENV KONG_VERSION 1.1.0rc1
+ENV KONG_VERSION 1.1.0
 
 ARG SU_EXEC_VERSION=0.2
 ARG SU_EXEC_URL="https://github.com/ncopa/su-exec/archive/v${SU_EXEC_VERSION}.tar.gz"
@@ -16,7 +16,7 @@ RUN yum install -y -q gcc make unzip \
 && rm -fr /var/cache/yum/* /tmp/yum_save*.yumtx /root/.pki
 
 RUN useradd --uid 1337 kong \
-    && yum install -y https://bintray.com/kong/kong-rpm/download_file?file_path=kong-$KONG_VERSION.el7.noarch.rpm \
+    && yum install -y https://bintray.com/kong/kong-rpm/download_file?file_path=centos/7/kong-$KONG_VERSION.el7.noarch.rpm \
     && yum clean all
 
 COPY docker-entrypoint.sh /docker-entrypoint.sh


### PR DESCRIPTION
Uses the new travis-ci generated alpine tar which includes a repository rename and package name change