### PR TITLE
fix(openshift) openshift runs containers with random UID

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -17,8 +17,7 @@ RUN adduser -Su 1337 kong \
 	&& cp -R /tmp/etc / \
 	&& rm -rf /tmp/etc \
 	&& apk del .build-deps \
-	&& chown -R kong /usr/local/kong \
-	&& chgrp -R 0 /usr/local/kong \
+	&& chown -R kong:0 /usr/local/kong \
 	&& chmod -R g=u /usr/local/kong
 
 COPY docker-entrypoint.sh /docker-entrypoint.sh

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -16,7 +16,10 @@ RUN adduser -Su 1337 kong \
 	&& rm -rf /tmp/usr \
 	&& cp -R /tmp/etc / \
 	&& rm -rf /tmp/etc \
-	&& apk del .build-deps
+	&& apk del .build-deps \
+	&& chown -R kong /usr/local/kong \
+	&& chgrp -R 0 /usr/local/kong \
+	&& chmod -R g=u /usr/local/kong
 
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 

--- a/alpine/docker-entrypoint.sh
+++ b/alpine/docker-entrypoint.sh
@@ -14,10 +14,6 @@ if [[ "$1" == "kong" ]]; then
     shift 2
     kong prepare -p "$PREFIX" "$@"
 
-    # workaround for https://github.com/moby/moby/issues/31243
-    chmod o+w /proc/self/fd/1
-    chmod o+w /proc/self/fd/2
-
     if [ "$(id -u)" != "0" ]; then
       exec /usr/local/openresty/nginx/sbin/nginx \
         -p "$PREFIX" \
@@ -28,6 +24,9 @@ if [[ "$1" == "kong" ]]; then
           || has_transparent "$KONG_PROXY_LISTEN" \
           || has_transparent "$KONG_ADMIN_LISTEN";
       then
+        # workaround for https://github.com/moby/moby/issues/31243
+        chmod o+w /proc/self/fd/1
+        chmod o+w /proc/self/fd/2
         setcap cap_net_raw=+ep /usr/local/openresty/nginx/sbin/nginx
       fi
       chown -R kong:0 /usr/local/kong

--- a/alpine/docker-entrypoint.sh
+++ b/alpine/docker-entrypoint.sh
@@ -20,8 +20,8 @@ if [[ "$1" == "kong" ]]; then
 
     if [ "$(id -u)" != "0" ]; then
       exec /usr/local/openresty/nginx/sbin/nginx \
-      -p "$PREFIX" \
-      -c nginx.conf
+        -p "$PREFIX" \
+        -c nginx.conf
     else
       if [ ! -z ${SET_CAP_NET_RAW} ] \
           || has_transparent "$KONG_STREAM_LISTEN" \
@@ -30,6 +30,7 @@ if [[ "$1" == "kong" ]]; then
       then
         setcap cap_net_raw=+ep /usr/local/openresty/nginx/sbin/nginx
       fi
+      chown -R kong:0 /usr/local/kong
       exec su-exec kong /usr/local/openresty/nginx/sbin/nginx \
         -p "$PREFIX" \
         -c nginx.conf

--- a/alpine/docker-entrypoint.sh
+++ b/alpine/docker-entrypoint.sh
@@ -13,6 +13,10 @@ if [[ "$1" == "kong" ]]; then
   if [[ "$2" == "docker-start" ]]; then
     shift 2
     kong prepare -p "$PREFIX" "$@"
+    
+    # workaround for https://github.com/moby/moby/issues/31243
+    chmod o+w /proc/self/fd/1 || true
+    chmod o+w /proc/self/fd/2 || true
 
     if [ "$(id -u)" != "0" ]; then
       exec /usr/local/openresty/nginx/sbin/nginx \
@@ -24,9 +28,6 @@ if [[ "$1" == "kong" ]]; then
           || has_transparent "$KONG_PROXY_LISTEN" \
           || has_transparent "$KONG_ADMIN_LISTEN";
       then
-        # workaround for https://github.com/moby/moby/issues/31243
-        chmod o+w /proc/self/fd/1
-        chmod o+w /proc/self/fd/2
         setcap cap_net_raw=+ep /usr/local/openresty/nginx/sbin/nginx
       fi
       chown -R kong:0 /usr/local/kong

--- a/alpine/docker-entrypoint.sh
+++ b/alpine/docker-entrypoint.sh
@@ -13,23 +13,27 @@ if [[ "$1" == "kong" ]]; then
   if [[ "$2" == "docker-start" ]]; then
     shift 2
     kong prepare -p "$PREFIX" "$@"
-    chown -R kong "$PREFIX"
 
     # workaround for https://github.com/moby/moby/issues/31243
     chmod o+w /proc/self/fd/1
     chmod o+w /proc/self/fd/2
 
-    if [ ! -z ${SET_CAP_NET_RAW} ] \
-        || has_transparent "$KONG_STREAM_LISTEN" \
-        || has_transparent "$KONG_PROXY_LISTEN" \
-        || has_transparent "$KONG_ADMIN_LISTEN";
-    then
-      setcap cap_net_raw=+ep /usr/local/openresty/nginx/sbin/nginx
-    fi
-
-    exec su-exec kong /usr/local/openresty/nginx/sbin/nginx \
+    if [ "$(id -u)" != "0" ]; then
+      exec /usr/local/openresty/nginx/sbin/nginx \
       -p "$PREFIX" \
       -c nginx.conf
+    else
+      if [ ! -z ${SET_CAP_NET_RAW} ] \
+          || has_transparent "$KONG_STREAM_LISTEN" \
+          || has_transparent "$KONG_PROXY_LISTEN" \
+          || has_transparent "$KONG_ADMIN_LISTEN";
+      then
+        setcap cap_net_raw=+ep /usr/local/openresty/nginx/sbin/nginx
+      fi
+      exec su-exec kong /usr/local/openresty/nginx/sbin/nginx \
+        -p "$PREFIX" \
+        -c nginx.conf
+    fi
   fi
 fi
 

--- a/centos/Dockerfile
+++ b/centos/Dockerfile
@@ -19,8 +19,7 @@ RUN useradd --uid 1337 kong \
 	&& mkdir -p "/usr/local/kong" \
 	&& yum install -y https://bintray.com/kong/kong-rpm/download_file?file_path=centos/7/kong-$KONG_VERSION.el7.noarch.rpm \
 	&& yum clean all \
-	&& chown -R kong /usr/local/kong \
-	&& chgrp -R 0 /usr/local/kong \
+	&& chown -R kong:0 /usr/local/kong \
 	&& chmod -R g=u /usr/local/kong
 
 COPY docker-entrypoint.sh /docker-entrypoint.sh

--- a/centos/Dockerfile
+++ b/centos/Dockerfile
@@ -7,17 +7,21 @@ ARG SU_EXEC_VERSION=0.2
 ARG SU_EXEC_URL="https://github.com/ncopa/su-exec/archive/v${SU_EXEC_VERSION}.tar.gz"
 
 RUN yum install -y -q gcc make unzip \
-&& curl -sL "${SU_EXEC_URL}" | tar -C /tmp -zxf - \
-&& make -C "/tmp/su-exec-${SU_EXEC_VERSION}" \
-&& cp "/tmp/su-exec-${SU_EXEC_VERSION}/su-exec" /usr/bin \
-&& rm -fr "/tmp/su-exec-${SU_EXEC_VERSION}" \
-&& yum autoremove -y -q gcc make \
-&& yum clean all -q \
-&& rm -fr /var/cache/yum/* /tmp/yum_save*.yumtx /root/.pki
+	&& curl -sL "${SU_EXEC_URL}" | tar -C /tmp -zxf - \
+	&& make -C "/tmp/su-exec-${SU_EXEC_VERSION}" \
+	&& cp "/tmp/su-exec-${SU_EXEC_VERSION}/su-exec" /usr/bin \
+	&& rm -fr "/tmp/su-exec-${SU_EXEC_VERSION}" \
+	&& yum autoremove -y -q gcc make \
+	&& yum clean all -q \
+	&& rm -fr /var/cache/yum/* /tmp/yum_save*.yumtx /root/.pki
 
 RUN useradd --uid 1337 kong \
-    && yum install -y https://bintray.com/kong/kong-rpm/download_file?file_path=centos/7/kong-$KONG_VERSION.el7.noarch.rpm \
-    && yum clean all
+	&& mkdir -p "/usr/local/kong" \
+	&& yum install -y https://bintray.com/kong/kong-rpm/download_file?file_path=centos/7/kong-$KONG_VERSION.el7.noarch.rpm \
+	&& yum clean all \
+	&& chown -R kong /usr/local/kong \
+	&& chgrp -R 0 /usr/local/kong \
+	&& chmod -R g=u /usr/local/kong
 
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 

--- a/centos/docker-entrypoint.sh
+++ b/centos/docker-entrypoint.sh
@@ -14,10 +14,6 @@ if [[ "$1" == "kong" ]]; then
     shift 2
     kong prepare -p "$PREFIX" "$@"
 
-    # workaround for https://github.com/moby/moby/issues/31243
-    chmod o+w /proc/self/fd/1
-    chmod o+w /proc/self/fd/2
-
     if [ "$(id -u)" != "0" ]; then
       exec /usr/local/openresty/nginx/sbin/nginx \
         -p "$PREFIX" \
@@ -28,6 +24,9 @@ if [[ "$1" == "kong" ]]; then
           || has_transparent "$KONG_PROXY_LISTEN" \
           || has_transparent "$KONG_ADMIN_LISTEN";
       then
+        # workaround for https://github.com/moby/moby/issues/31243
+        chmod o+w /proc/self/fd/1
+        chmod o+w /proc/self/fd/2
         setcap cap_net_raw=+ep /usr/local/openresty/nginx/sbin/nginx
       fi
       chown -R kong:0 /usr/local/kong

--- a/centos/docker-entrypoint.sh
+++ b/centos/docker-entrypoint.sh
@@ -20,8 +20,8 @@ if [[ "$1" == "kong" ]]; then
 
     if [ "$(id -u)" != "0" ]; then
       exec /usr/local/openresty/nginx/sbin/nginx \
-      -p "$PREFIX" \
-      -c nginx.conf
+        -p "$PREFIX" \
+        -c nginx.conf
     else
       if [ ! -z ${SET_CAP_NET_RAW} ] \
           || has_transparent "$KONG_STREAM_LISTEN" \
@@ -30,6 +30,7 @@ if [[ "$1" == "kong" ]]; then
       then
         setcap cap_net_raw=+ep /usr/local/openresty/nginx/sbin/nginx
       fi
+      chown -R kong:0 /usr/local/kong
       exec su-exec kong /usr/local/openresty/nginx/sbin/nginx \
         -p "$PREFIX" \
         -c nginx.conf

--- a/centos/docker-entrypoint.sh
+++ b/centos/docker-entrypoint.sh
@@ -14,6 +14,10 @@ if [[ "$1" == "kong" ]]; then
     shift 2
     kong prepare -p "$PREFIX" "$@"
 
+    # workaround for https://github.com/moby/moby/issues/31243
+    chmod o+w /proc/self/fd/1 || true
+    chmod o+w /proc/self/fd/2 || true
+
     if [ "$(id -u)" != "0" ]; then
       exec /usr/local/openresty/nginx/sbin/nginx \
         -p "$PREFIX" \
@@ -24,9 +28,6 @@ if [[ "$1" == "kong" ]]; then
           || has_transparent "$KONG_PROXY_LISTEN" \
           || has_transparent "$KONG_ADMIN_LISTEN";
       then
-        # workaround for https://github.com/moby/moby/issues/31243
-        chmod o+w /proc/self/fd/1
-        chmod o+w /proc/self/fd/2
         setcap cap_net_raw=+ep /usr/local/openresty/nginx/sbin/nginx
       fi
       chown -R kong:0 /usr/local/kong

--- a/centos/docker-entrypoint.sh
+++ b/centos/docker-entrypoint.sh
@@ -13,23 +13,27 @@ if [[ "$1" == "kong" ]]; then
   if [[ "$2" == "docker-start" ]]; then
     shift 2
     kong prepare -p "$PREFIX" "$@"
-    chown -R kong "$PREFIX"
 
     # workaround for https://github.com/moby/moby/issues/31243
     chmod o+w /proc/self/fd/1
     chmod o+w /proc/self/fd/2
 
-    if [ ! -z ${SET_CAP_NET_RAW} ] \
-        || has_transparent "$KONG_STREAM_LISTEN" \
-        || has_transparent "$KONG_PROXY_LISTEN" \
-        || has_transparent "$KONG_ADMIN_LISTEN";
-    then
-      setcap cap_net_raw=+ep /usr/local/openresty/nginx/sbin/nginx
-    fi
-
-    exec su-exec kong /usr/local/openresty/nginx/sbin/nginx \
+    if [ "$(id -u)" != "0" ]; then
+      exec /usr/local/openresty/nginx/sbin/nginx \
       -p "$PREFIX" \
       -c nginx.conf
+    else
+      if [ ! -z ${SET_CAP_NET_RAW} ] \
+          || has_transparent "$KONG_STREAM_LISTEN" \
+          || has_transparent "$KONG_PROXY_LISTEN" \
+          || has_transparent "$KONG_ADMIN_LISTEN";
+      then
+        setcap cap_net_raw=+ep /usr/local/openresty/nginx/sbin/nginx
+      fi
+      exec su-exec kong /usr/local/openresty/nginx/sbin/nginx \
+        -p "$PREFIX" \
+        -c nginx.conf
+    fi
   fi
 fi
 

--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -25,6 +25,7 @@ services:
     restart: on-failure
   kong:
     image: "${KONG_DOCKER_TAG:-kong:latest}"
+    user: "${KONG_USER:-root}"
     depends_on:
       db:
         condition: service_healthy

--- a/tests.sh
+++ b/tests.sh
@@ -46,3 +46,17 @@ popd
 
 pushd kong-build-tools
 TEST_HOST=`hostname --ip-address` KONG_VERSION=$version_given make run_tests
+popd
+
+pushd compose
+docker-compose stop
+KONG_USER=1001 docker-compose up -d
+until docker-compose ps | grep compose_kong_1 | grep -q "Up"; do sleep 1; done
+docker-compose exec kong ps aux | sed -n 2p | grep -q 1001
+if [ $? -ne 0 ]; then
+  echo "Kong is not running as the overridden 1001 user";
+  echo "\tRunning instead as ";
+  docker-compose exec kong ps aux | sed -n 2p
+  exit 1;
+fi
+popd

--- a/tests.sh
+++ b/tests.sh
@@ -26,7 +26,7 @@ popd
 pushd compose
 docker-compose up -d
 until docker-compose ps | grep compose_kong_1 | grep -q "Up"; do sleep 1; done
-
+sleep 10
 docker-compose exec kong ps aux | sed -n 2p | grep -q kong
 if [ $? -ne 0 ]; then
   echo "Kong is not running as the Kong user";
@@ -52,6 +52,7 @@ pushd compose
 docker-compose stop
 KONG_USER=1001 docker-compose up -d
 until docker-compose ps | grep compose_kong_1 | grep -q "Up"; do sleep 1; done
+sleep 10
 docker-compose exec kong ps aux | sed -n 2p | grep -q 1001
 if [ $? -ne 0 ]; then
   echo "Kong is not running as the overridden 1001 user";


### PR DESCRIPTION
If the kong container is ran with UID 0 (root) assume the desired behaviour is to `su-exec` run Kong with the Kong user (aka 1337) but if it's ran with a non 0 UID assume we want Kong to run as that user.