### PR TITLE
fix: send QUIT instead of TERM for graceful shutdown

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -26,6 +26,6 @@ ENTRYPOINT ["/docker-entrypoint.sh"]
 
 EXPOSE 8000 8443 8001 8444
 
-STOPSIGNAL SIGTERM
+STOPSIGNAL SIGQUIT
 
 CMD ["kong", "docker-start"]

--- a/centos/Dockerfile
+++ b/centos/Dockerfile
@@ -28,6 +28,6 @@ ENTRYPOINT ["/docker-entrypoint.sh"]
 
 EXPOSE 8000 8443 8001 8444
 
-STOPSIGNAL SIGTERM
+STOPSIGNAL SIGQUIT
 
 CMD ["kong", "docker-start"]

--- a/rhel/Dockerfile
+++ b/rhel/Dockerfile
@@ -29,6 +29,6 @@ ENTRYPOINT ["/docker-entrypoint.sh"]
 
 EXPOSE 8000 8443 8001 8444
 
-STOPSIGNAL SIGTERM
+STOPSIGNAL SIGQUIT
 
 CMD ["kong", "docker-start"]


### PR DESCRIPTION
While running in any docker environment like Docker swarm or k8s,
sending a SIGTERM to Kong will drop in-flight requests.

NGINX has decided to keep using SIGTERM because UNIX domain sockets are
not cleaned up properly while using SIGQUIT:
https://github.com/nginxinc/docker-nginx/issues/167
https://github.com/nginxinc/docker-nginx/issues/46
https://trac.nginx.org/nginx/ticket/753

OpenResty, on the other hand, uses SIGQUIT as using UNIX domain sockets
are _usually_ not used with OpenResty:
https://github.com/openresty/docker-openresty/commit/709f99f76af87009f278fdf68684c8712942d44a