### PR TITLE
chore(rhel) Redhat is updating their base image name

### DIFF
--- a/rhel/Dockerfile
+++ b/rhel/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/rhel7
+FROM registry.access.redhat.com/ubi7/ubi
 
 MAINTAINER Kong
 


### PR DESCRIPTION
![Capture](https://user-images.githubusercontent.com/697188/59859931-b03b0900-934b-11e9-9b40-c63f571a6ca1.PNG)
