### PR TITLE
fixed(customize) crate missing plugins directory

### DIFF
--- a/customize/packer.lua
+++ b/customize/packer.lua
@@ -201,6 +201,12 @@ local function install_plugins(plugins, lr_flag)
   end
 end
 
+local function create_plugins_directory() 
+  local ok = exec("mkdir plugins")
+  if not ok then
+    fail(("failed to create plugins dir"))
+  end
+end
 
 local function pack_rocks(rocks)
   local cmd = "cd /plugins && luarocks pack %s %s"
@@ -331,6 +337,8 @@ for plugin_name in pairs(get_plugins()) do
   end
 end
 
+header("Creare plugins directory")
+create_plugins_directory() 
 
 header("Pack newly installed rocks")
 pack_rocks(added_rocks)
@@ -403,4 +411,3 @@ stdout(script)
 
 
 header("Completed packing rocks and/or template")
-


### PR DESCRIPTION
I open this pull request because when i try to build a kong image with only a custom plugin 

```
docker build \
   --build-arg "KONG_LICENSE_DATA=$KONG_LICENSE_DATA" \
   --build-arg KONG_BASE="kong:latest" \
   --build-arg PLUGINS="kong-plugin-aws-firehose-log,kong-plugin-aws-kinesis-log" \
   --build-arg ROCKS_DIR="./rocksdir" \
   --tag "kong" .
```
I receive this error

```
...

********************************************************************************
*                          Pack newly installed rocks                          *
********************************************************************************
cd /plugins && luarocks pack kong-plugin-aws-firehose-log 0.1.0-1
[packer exec] cd /plugins && luarocks pack kong-plugin-aws-firehose-log 0.1.0-1
sh: cd: line 1: can't cd to /plugins: No such file or directory
failed packing rock: 'kong-plugin-aws-firehose-log-0.1.0-1' failed
The command '/bin/sh -c /usr/local/openresty/luajit/bin/luajit /packer.lua -- "$INJECTED_PLUGINS"' returned a non-zero code: 1
```

