### PR TITLE
feat(entrypoint) allow users to configure uid/gid of kong user

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -7,7 +7,8 @@ ENV KONG_SHA256 97fe67e777edab2b243f8510df78e8fddc77ce5681eaf909f363d3c521c4591f
 RUN adduser -Su 1337 kong \
 	&& mkdir -p "/usr/local/kong" \
 	&& apk add --no-cache --virtual .build-deps wget tar ca-certificates \
-	&& apk add --no-cache libgcc openssl pcre perl tzdata curl libcap su-exec zip \
+	&& apk add --no-cache libgcc openssl pcre perl tzdata curl libcap su-exec \
+	&& apk add --no-cache shadow zip \
 	&& wget -O kong.tar.gz "https://bintray.com/kong/kong-alpine-tar/download_file?file_path=kong-$KONG_VERSION.apk.tar.gz" \
 	&& echo "$KONG_SHA256 *kong.tar.gz" | sha256sum -c - \
 	&& tar -xzf kong.tar.gz -C /tmp \

--- a/alpine/docker-entrypoint.sh
+++ b/alpine/docker-entrypoint.sh
@@ -7,6 +7,12 @@ has_transparent() {
   echo "$1" | grep -E "[^\s,]+\s+transparent\b" >/dev/null
 }
 
+# override UID of kong user
+
+if [[ ! -z "${KONG_UID}" ]]; then
+  /usr/sbin/usermod -u ${KONG_UID} kong
+fi
+
 if [[ "$1" == "kong" ]]; then
   PREFIX=${KONG_PREFIX:=/usr/local/kong}
 

--- a/centos/docker-entrypoint.sh
+++ b/centos/docker-entrypoint.sh
@@ -7,6 +7,16 @@ has_transparent() {
   echo "$1" | grep -E "[^\s,]+\s+transparent\b" >/dev/null
 }
 
+# override UID and GID of kong user
+
+if [[ ! -z "${KONG_UID}" ]]; then
+  /sbin/usermod -u ${KONG_UID} kong
+fi
+
+if [[ ! -z "${KONG_GID}" ]]; then
+  /sbin/groupmod -g ${KONG_GID} kong
+fi
+
 if [[ "$1" == "kong" ]]; then
   PREFIX=${KONG_PREFIX:=/usr/local/kong}
 


### PR DESCRIPTION
If `KONG_UID` or `KONG_GID` environment variable is set, change the uid
and gid of the kong user (and group if it exists).

On alpine, kong group doesn't exist, so that is not allowed.

This change makes Kong compatible with Istio.

From https://istio.io/docs/setup/kubernetes/additional-setup/requirements/:

> Application UIDs: Ensure your pods do not run applications as a user
with the user ID (UID) value of 1337.