### PR TITLE
Run `kong prepare` as `kong` user if we are root.

### DIFF
--- a/alpine/docker-entrypoint.sh
+++ b/alpine/docker-entrypoint.sh
@@ -12,8 +12,12 @@ if [[ "$1" == "kong" ]]; then
 
   if [[ "$2" == "docker-start" ]]; then
     shift 2
-    kong prepare -p "$PREFIX" "$@"
-    
+    if [ "$(id -u)" != "0" ]; then
+        kong prepare -p "$PREFIX" "$@"
+    else
+        su-exec kong kong prepare -p "$PREFIX" "$@"
+    fi
+
     # workaround for https://github.com/moby/moby/issues/31243
     chmod o+w /proc/self/fd/1 || true
     chmod o+w /proc/self/fd/2 || true

--- a/centos/docker-entrypoint.sh
+++ b/centos/docker-entrypoint.sh
@@ -12,7 +12,11 @@ if [[ "$1" == "kong" ]]; then
 
   if [[ "$2" == "docker-start" ]]; then
     shift 2
-    kong prepare -p "$PREFIX" "$@"
+    if [ "$(id -u)" != "0" ]; then
+        kong prepare -p "$PREFIX" "$@"
+    else
+        su-exec kong kong prepare -p "$PREFIX" "$@"
+    fi
 
     # workaround for https://github.com/moby/moby/issues/31243
     chmod o+w /proc/self/fd/1 || true


### PR DESCRIPTION
The `kong prepare` command also needs to be run as `kong` user (if the entrypoint is executed by `root` otherwise Kong may create some files (e.g.: the log file defined with `KONG_PROXY_ACCESS_LOG`) as root. Then `nginx`, run as `kong` will have permissions to write in this log file.

To reproduce the error
-----------------------------

I used this `docker-compose.yml` file:

```
# vim:ft=yaml tabstop=2 shiftwidth=2 softtabstop=2
version: "2"

services:
  db:
    image: postgres:10
    environment:
      - POSTGRES_USER=kong
      - POSTGRES_DB=kong

  kong:
    build: alpine/
    environment:
      - KONG_DATABASE=postgres
      - KONG_PG_HOST=db
      - KONG_PROXY_ACCESS_LOG=/tmp/access.log
```
So `KONG_PROXY_ACCESS_LOG` is set to `/tmp/access.log`.

Then:
```bash
$ docker-compose up -d db
Creating network "docker-kong_default" with the default driver
Creating docker-kong_db_1 ... done

# Waiting a few seconds for Postgres to start then
$ docker-compose run kong kong migrations bootstrap
Bootstrapping database...
[...]
27 executed
Database is up-to-date

$ docker-compose up kong
Creating docker-kong_kong_1 ... done
Attaching to docker-kong_kong_1
kong_1  | nginx: [emerg] open() "/tmp/access.log" failed (13: Permission denied)
docker-kong_kong_1 exited with code 1
```