### PR TITLE
fix(openshift) allow images to run as user kong

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -20,6 +20,8 @@ RUN adduser -Su 1337 kong \
 	&& chown -R kong:0 /usr/local/kong \
 	&& chmod -R g=u /usr/local/kong
 
+USER kong
+
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/alpine/docker-entrypoint.sh
+++ b/alpine/docker-entrypoint.sh
@@ -13,10 +13,10 @@ if [[ "$1" == "kong" ]]; then
   if [[ "$2" == "docker-start" ]]; then
     shift 2
     kong prepare -p "$PREFIX" "$@"
-    
-    # workaround for https://github.com/moby/moby/issues/31243
-    chmod o+w /proc/self/fd/1 || true
-    chmod o+w /proc/self/fd/2 || true
+
+    ln -sf /dev/stdout $PREFIX/logs/access.log
+    ln -sf /dev/stdout $PREFIX/logs/admin_access.log
+    ln -sf /dev/stderr $PREFIX/logs/error.log
 
     if [ "$(id -u)" != "0" ]; then
       exec /usr/local/openresty/nginx/sbin/nginx \

--- a/centos/Dockerfile
+++ b/centos/Dockerfile
@@ -22,6 +22,8 @@ RUN useradd --uid 1337 kong \
 	&& chown -R kong:0 /usr/local/kong \
 	&& chmod -R g=u /usr/local/kong
 
+USER kong
+
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/centos/docker-entrypoint.sh
+++ b/centos/docker-entrypoint.sh
@@ -14,9 +14,9 @@ if [[ "$1" == "kong" ]]; then
     shift 2
     kong prepare -p "$PREFIX" "$@"
 
-    # workaround for https://github.com/moby/moby/issues/31243
-    chmod o+w /proc/self/fd/1 || true
-    chmod o+w /proc/self/fd/2 || true
+    ln -sf /dev/stdout $PREFIX/logs/access.log
+    ln -sf /dev/stdout $PREFIX/logs/admin_access.log
+    ln -sf /dev/stderr $PREFIX/logs/error.log
 
     if [ "$(id -u)" != "0" ]; then
       exec /usr/local/openresty/nginx/sbin/nginx \

--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -42,7 +42,7 @@ services:
     restart: on-failure
   kong:
     image: "${KONG_DOCKER_TAG:-kong:latest}"
-    user: "${KONG_USER:-root}"
+    user: "${KONG_USER:-kong}"
     depends_on:
       db:
         condition: service_healthy

--- a/swarm/docker-compose.yml
+++ b/swarm/docker-compose.yml
@@ -40,7 +40,7 @@ services:
         delay: 2s
   kong:
     image: "${KONG_DOCKER_TAG:-kong:latest}"
-    user: "${KONG_USER:-root}"
+    user: "${KONG_USER:-kong}"
     environment:
       KONG_ADMIN_ACCESS_LOG: /dev/stdout
       KONG_ADMIN_ERROR_LOG: /dev/stderr

--- a/tests.sh
+++ b/tests.sh
@@ -15,7 +15,7 @@ if [[ "$version_given" != "$version_built" ]]; then
 fi
 
 # Test LuaRocks is functional for installing rocks
-docker run -ti kong-$BASE /bin/sh -c "luarocks install version"
+docker run -ti --user=root kong-$BASE /bin/sh -c "luarocks install version"
 popd
 
 # Docker swarm test


### PR DESCRIPTION
Per the OpenShift docs [1] if the Dockerfile does not have the USER
directive, it will be run as the root UID, which was the case for our
alpine and centos images. The problem is that running as root on some
OpenShift setups (e.g. Minishift) did not allow Kong to be started:

```
~/Downloads$ oc logs -f deployment/kong-rc
chmod: /proc/self/fd/1: Permission denied
chmod: /proc/self/fd/2: Permission denied
nginx: [emerg] open() "/dev/stderr" failed (13: Permission denied)
```

This fixes an OpenShift issue where images were not running as root
because no USER was specified in the alpine and centos dockerfiles.

[1]
https://docs.openshift.com/enterprise/3.2/admin_guide/manage_scc.html#enable-images-to-run-with-user-in-the-dockerfile