### PR TITLE
Fixing docker-compose file

### DIFF
--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -1,10 +1,11 @@
 version: '2.1'
 
 volumes:
-    kong_data: {}
+  kong_data: {}
 
 networks:
   kong-net:
+
 services:
   kong-migrations:
     image: "${KONG_DOCKER_TAG:-kong:latest}"
@@ -18,11 +19,10 @@ services:
       KONG_PG_HOST: db
       KONG_PG_PASSWORD: ${KONG_PG_PASSWORD:-kong}
       KONG_PG_USER: ${KONG_PG_USER:-kong}
-    links:
-      - db:db
     networks:
       - kong-net
     restart: on-failure
+
   kong-migrations-up:
     image: "${KONG_DOCKER_TAG:-kong:latest}"
     command: kong migrations up && kong migrations finish
@@ -35,11 +35,10 @@ services:
       KONG_PG_HOST: db
       KONG_PG_PASSWORD: ${KONG_PG_PASSWORD:-kong}
       KONG_PG_USER: ${KONG_PG_USER:-kong}
-    links:
-      - db:db
     networks:
       - kong-net
     restart: on-failure
+
   kong:
     image: "${KONG_DOCKER_TAG:-kong:latest}"
     user: "${KONG_USER:-root}"
@@ -71,6 +70,7 @@ services:
       timeout: 10s
       retries: 10
     restart: on-failure
+    
   db:
     image: postgres:9.5
     environment:


### PR DESCRIPTION
As we are already using `networks` so there is no need to use `links` which is also deprecated in the updated version as well as it is also recommended to use networks over links.

Moreover, we are adding the same name as the service name in the alias so it's of no use.