### PR TITLE
release: 2.0.0

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,8 +1,8 @@
 FROM alpine:3.10
 LABEL maintainer="Kong Core Team <team-core@konghq.com>"
 
-ENV KONG_VERSION 2.0.0rc2
-ENV KONG_SHA256 fcfa87d8bdd3d8216e782f595ca4bfb1f38f83ae4a65722fff95781a54ed7f88
+ENV KONG_VERSION 2.0.0
+ENV KONG_SHA256 5af1178111958b2e325c5b18690f4e7ddf064d28139ff38188b1e2e432ea99ff
 
 
 RUN adduser -S kong \

--- a/centos/Dockerfile
+++ b/centos/Dockerfile
@@ -1,7 +1,7 @@
 FROM centos:7
 LABEL maintainer="Kong Core Team <team-core@konghq.com>"
 
-ENV KONG_VERSION 2.0.0rc2
+ENV KONG_VERSION 2.0.0
 
 RUN yum install -y -q unzip \
 	&& yum clean all -q \

--- a/rhel/Dockerfile
+++ b/rhel/Dockerfile
@@ -2,7 +2,7 @@ FROM registry.access.redhat.com/ubi7/ubi
 
 MAINTAINER Kong
 
-ENV KONG_VERSION 2.0.0rc2
+ENV KONG_VERSION 2.0.0
 
 LABEL name="Kong" \
       vendor="Kong" \

--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:xenial
 LABEL maintainer="Kong Core Team <team-core@konghq.com>"
 
-ENV KONG_VERSION 2.0.0rc2
+ENV KONG_VERSION 2.0.0
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates curl perl unzip \


### PR DESCRIPTION
- bump to Kong 2.0
- ~~bump to kong-build-tools 3.0 - for go smoke tests~~ (skipping that for now - go tests already run for base packages - will come back to it later on)