### PR TITLE
fix(customize) use root user to install things

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ env:
   matrix:
     - BASE="centos" KONG_DOCKER_TAG="kong-centos"
     - BASE="alpine" KONG_DOCKER_TAG="kong-alpine"
-    - BASE="ubuntu" KONG_DOCKER_TAG="kong-ubuntu"
     - BASE="rhel" KONG_DOCKER_TAG="kong-rhel"
 
 before_script:

--- a/customize/Dockerfile
+++ b/customize/Dockerfile
@@ -20,11 +20,17 @@ COPY $TEMPLATE /plugins/custom_nginx.conf
 COPY $ROCKS_DIR /rocks-server
 COPY packer.lua /packer.lua
 
-RUN /usr/local/openresty/luajit/bin/luajit /packer.lua -- "$INJECTED_PLUGINS"
+USER root
 
+RUN /usr/local/openresty/luajit/bin/luajit /packer.lua -- "$INJECTED_PLUGINS"
 
 
 FROM ${KONG_BASE}
 
 COPY --from=build /plugins /plugins
+
+USER root
+
 RUN /plugins/install_plugins.sh
+
+USER kong

--- a/tests.sh
+++ b/tests.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -e
+set -x
 
 # Test the proper version was buid
 pushd $BASE
@@ -84,4 +85,13 @@ popd
 pushd kong-build-tools
 rm -rf test/tests/03-go-plugins
 KONG_VERSION=$version_given KONG_TEST_CONTAINER_NAME=kong-$BASE KONG_TEST_IMAGE_NAME=kong-$BASE RESTY_IMAGE_TAG=$BASE make test
+popd
+
+pushd customize
+docker build \
+  --build-arg KONG_BASE="kong-$BASE" \
+  --build-arg PLUGINS="kong-http-to-https,kong-upstream-jwt" \
+  --tag "customize" .
+
+docker run -it --rm customize kong version
 popd


### PR DESCRIPTION
`2.0` migrated our docker images to run as user kong but one needs to use root to install plugins etc