### PR TITLE
chore(ci) the version variable no longer lives in the Dockerfile

### DIFF
--- a/submit.sh
+++ b/submit.sh
@@ -70,7 +70,7 @@ fi
 git checkout master
 git pull
 
-if ! grep -q "ENV KONG_VERSION $version$" alpine/Dockerfile
+if ! grep -q "$version" alpine/build-ce.sh
 then
    if [[ "$force" = "yes" ]]
    then
@@ -78,9 +78,9 @@ then
 
       git checkout "$version"
 
-      if ! grep -q "ENV KONG_VERSION $version$" alpine/Dockerfile
+      if ! grep -q "$version$" alpine/build-ce.sh
       then
-         die "Error: version in Dockerfile doesn't match required version."
+         die "Error: version in build script doesn't match required version."
       fi
    else
       echo "****************************************"


### PR DESCRIPTION
Didn't catch this change when we merged docker-kong-ee into docker-kong.

The version number moved out of the Dockerfiles into a bash script so `submit.sh` needs to be updated to reflect this change