### PR TITLE
fix(rhel) fix how the RedHat version label is set

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,12 @@ before_script:
 script:
   - make test
 
-deploy:
-  provider: script
-  script: BASE="rhel" KONG_DOCKER_TAG="kong-rhel" TAG=$TRAVIS_TAG make release-rhel
-  on:
-    tags: true
+jobs:
+  include:
+    - stage: deploy
+      env:
+        - BASE=rhel
+        - KONG_DOCKER_TAG=kong-rhel
+        - TAG=$TRAVIS_TAG
+      script: make release-rhel
+      if: tag IS present

--- a/rhel/Dockerfile
+++ b/rhel/Dockerfile
@@ -27,7 +27,7 @@ MAINTAINER Kong
 
 LABEL name="Kong" \
       vendor="Kong" \
-      version="${KONG_VERSION}" \
+      version="2.0.2" \
       release="1" \
       url="https://konghq.com" \
       summary="Next-Generation API Platform for Modern Architectures" \

--- a/update.sh
+++ b/update.sh
@@ -62,6 +62,8 @@ pushd rhel
    new_sha=$(sha256sum /tmp/kong.rpm.new | cut -b1-64)
    
    sed -i -e 's/'$old_sha'/'$new_sha'/g' build-ce.sh
+   sed -i -e "s/$prev_tag/$version/" Dockerfile
+   
    rm /tmp/kong.rpm.*
 popd
 


### PR DESCRIPTION
- redhad requires the version label be populated which we left it blank accidentally
- adjust the travis build to there isn't a deployment per matrix entry