### PR TITLE
refactor(test) use explicit env var instead of sed

### DIFF
--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -71,9 +71,9 @@ services:
       - kong-net
     ports:
       - "8000:8000/tcp"
-      - "127.0.0.1:8001:8001/tcp"
+      - "${KONG_ADMIN_HOST:-0.0.0.0}:8001:8001/tcp"
       - "8443:8443/tcp"
-      - "127.0.0.1:8444:8444/tcp"
+      - "${KONG_ADMIN_HOST:-0.0.0.0}:8444:8444/tcp"
     healthcheck:
       test: ["CMD", "kong", "health"]
       interval: 10s
@@ -83,7 +83,7 @@ services:
     deploy:
       restart_policy:
         condition: on-failure
-    
+
   db:
     image: postgres:9.5
     environment:

--- a/tests.sh
+++ b/tests.sh
@@ -29,8 +29,7 @@ done
 
 sleep 20
 curl -I localhost:8001 | grep 'Server: openresty'
-sed -i -e 's/127.0.0.1://g' docker-compose.yml
-KONG_DOCKER_TAG=${KONG_DOCKER_TAG} docker stack deploy -c docker-compose.yml kong
+KONG_ADMIN_HOST=127.0.0.1 KONG_DOCKER_TAG=${KONG_DOCKER_TAG} docker stack deploy -c docker-compose.yml kong
 sleep 20
 until docker ps | grep ${KONG_DOCKER_TAG}:latest | grep -q healthy; do
   docker stack ps kong


### PR DESCRIPTION
This PR removes a sed in favor of using an env var. Would 0.0.0.0 work as a default? or better just leaving it empty?

Not sure if we could even look for some more commonality by reusing KONG_ADMIN_LISTEN environment var, but one step at a time