### PR TITLE
added tini for the dockerfiles

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -36,9 +36,14 @@ RUN set -ex; \
 
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 
+# Add Tini
+ENV TINI_VERSION v0.10.0
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
+RUN chmod +x /tini
+
 USER kong
 
-ENTRYPOINT ["/docker-entrypoint.sh"]
+ENTRYPOINT ["/tini", "--", "/docker-entrypoint.sh"]
 
 EXPOSE 8000 8443 8001 8444
 

--- a/centos/Dockerfile
+++ b/centos/Dockerfile
@@ -32,9 +32,14 @@ RUN set -ex; \
 
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 
+# Add Tini
+ENV TINI_VERSION v0.10.0
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
+RUN chmod +x /tini
+
 USER kong
 
-ENTRYPOINT ["/docker-entrypoint.sh"]
+ENTRYPOINT ["/tini", "--", "/docker-entrypoint.sh"]
 
 EXPOSE 8000 8443 8001 8444
 

--- a/rhel/Dockerfile
+++ b/rhel/Dockerfile
@@ -43,9 +43,14 @@ RUN set -ex; \
 
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 
+# Add Tini
+ENV TINI_VERSION v0.10.0
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
+RUN chmod +x /tini
+
 USER kong
 
-ENTRYPOINT ["/docker-entrypoint.sh"]
+ENTRYPOINT ["/tini", "--", "/docker-entrypoint.sh"]
 
 EXPOSE 8000 8443 8001 8444
 

--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -31,11 +31,16 @@ RUN set -ex; \
 
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 
+# Add Tini
+ENV TINI_VERSION v0.10.0
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
+RUN chmod +x /tini
+
 USER kong
 
 RUN kong version
 
-ENTRYPOINT ["/docker-entrypoint.sh"]
+ENTRYPOINT ["/tini", "--", "/docker-entrypoint.sh"]
 
 EXPOSE 8000 8443 8001 8444
 


### PR DESCRIPTION
The fix to use dumb init / tini as a lite init system was added in [https://github.com/Kong/docker-kong/pull/48](https://github.com/Kong/docker-kong/pull/48), but seem to have missed in the docker files that are present currently. 
The PR is to add tini as a init system for the dockerfiles .
Ref: 
[docker-and-the-pid-1-zombie-reaping-problem]( https://blog.phusion.nl/2015/01/20/docker-and-the-pid-1-zombie-reaping-problem/.)