### PR TITLE
fix(ca-certificates) add ca-certificates to our alpine image

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -25,7 +25,7 @@ RUN set -ex; \
 	mv /kong/usr/local/* /usr/local && \
 	mv /kong/etc/* /etc && \
 	rm -rf /kong && \
-	apk add --no-cache libgcc openssl pcre perl tzdata libcap zip bash zlib zlib-dev git && \
+	apk add --no-cache libgcc openssl pcre perl tzdata libcap zip bash zlib zlib-dev git ca-certificates && \
 	adduser -S kong && \
 	mkdir -p "/usr/local/kong" && \
 	chown -R kong:0 /usr/local/kong && \


### PR DESCRIPTION
closes https://github.com/Kong/kong/issues/5919

```
docker build -t temp .
docker run -it --rm temp ls /etc/ssl/certs/ca-certificates.crt
/etc/ssl/certs/ca-certificates.crt
```