### PR TITLE
fix(docker) do not set empty vars

### DIFF
--- a/alpine/docker-entrypoint.sh
+++ b/alpine/docker-entrypoint.sh
@@ -9,7 +9,10 @@ file_env() {
 	local var="$1"
 	local fileVar="${var}_FILE"
 	local def="${2:-}"
-	if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+	# Do not continue if _FILE env is not set
+	if ! [ "${!fileVar:-}" ]; then
+		return
+	elif [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
 		echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
 		exit 1
 	fi

--- a/centos/docker-entrypoint.sh
+++ b/centos/docker-entrypoint.sh
@@ -9,7 +9,10 @@ file_env() {
 	local var="$1"
 	local fileVar="${var}_FILE"
 	local def="${2:-}"
-	if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+	# Do not continue if _FILE env is not set
+	if ! [ "${!fileVar:-}" ]; then
+		return
+	elif [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
 		echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
 		exit 1
 	fi

--- a/rhel/docker-entrypoint.sh
+++ b/rhel/docker-entrypoint.sh
@@ -9,7 +9,10 @@ file_env() {
 	local var="$1"
 	local fileVar="${var}_FILE"
 	local def="${2:-}"
-	if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+	# Do not continue if _FILE env is not set
+	if ! [ "${!fileVar:-}" ]; then
+		return
+	elif [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
 		echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
 		exit 1
 	fi

--- a/ubuntu/docker-entrypoint.sh
+++ b/ubuntu/docker-entrypoint.sh
@@ -9,7 +9,10 @@ file_env() {
 	local var="$1"
 	local fileVar="${var}_FILE"
 	local def="${2:-}"
-	if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+	# Do not continue if _FILE env is not set
+	if ! [ "${!fileVar:-}" ]; then
+		return
+	elif [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
 		echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
 		exit 1
 	fi


### PR DESCRIPTION
file_env sets empty envs when is run. This PR adds a safeguard for that case. If `<smth>_FILE` is not set the function does not need to run.