### PR TITLE
fix(dependencies) remove uneeded dev dependencies

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -26,7 +26,7 @@ RUN set -ex; \
 	mv /kong/usr/local/* /usr/local && \
 	mv /kong/etc/* /etc && \
 	rm -rf /kong && \
-	apk add --no-cache libstdc++ libgcc openssl pcre perl tzdata libcap zip bash zlib zlib-dev git ca-certificates && \
+	apk add --no-cache libstdc++ libgcc openssl pcre perl tzdata libcap zip bash zlib git ca-certificates && \
 	adduser -S kong && \
 	mkdir -p "/usr/local/kong" && \
 	chown -R kong:0 /usr/local/kong && \

--- a/centos/Dockerfile
+++ b/centos/Dockerfile
@@ -20,7 +20,7 @@ RUN set -ex; \
 		curl -fL "https://bintray.com/kong/kong-prerelease/download_file?file_path=centos/7/kong-$KONG_VERSION.el7.amd64.rpm" -o /tmp/kong.rpm \
 		&& echo "$KONG_SHA256  /tmp/kong.rpm" | sha256sum -c -; \
 	fi; \
-	yum install -y -q unzip shadow-utils git zlib zlib-devel \
+	yum install -y -q unzip shadow-utils git zlib \
 	&& yum clean all -q \
 	&& rm -fr /var/cache/yum/* /tmp/yum_save*.yumtx /root/.pki \
 	&& useradd kong \

--- a/rhel/Dockerfile
+++ b/rhel/Dockerfile
@@ -29,7 +29,7 @@ RUN set -ex; \
         curl -fL "https://bintray.com/kong/kong-prerelease/download_file?file_path=rhel/7/kong-$KONG_VERSION.rhel7.amd64.rpm" -o /tmp/kong.rpm \
         && echo "$KONG_SHA256  /tmp/kong.rpm" | sha256sum -c -; \
     fi; \
-    yum install -y -q unzip shadow-utils zlib zlib-devel \
+    yum install -y -q unzip shadow-utils zlib \
 	&& yum clean all -q \
 	&& rm -fr /var/cache/yum/* /tmp/yum_save*.yumtx /root/.pki \
 	&& useradd kong \

--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -18,9 +18,7 @@ RUN set -ex; \
         && apt-get purge -y curl; \
     fi; \
     apt-get update \
-    && apt-get install -y --no-install-recommends perl unzip git \
-    && { apt-get install -y --no-install-recommends zlibc || true; } \
-    && { apt-get install -y --no-install-recommends zlib1g-dev || true; } \
+    && apt-get install -y --no-install-recommends perl unzip git zlib1g \
     && rm -rf /var/lib/apt/lists/* \
 	&& dpkg -i /tmp/kong.deb \
 	&& rm -rf /tmp/kong.deb \


### PR DESCRIPTION
during the 2.0.5 release the docker team questioned the need for these `-dev` packages. After some sleuthing / testing we've determined they're not required