### PR TITLE
chore(dependencies) infer dependencies from the packages

### DIFF
--- a/centos/Dockerfile
+++ b/centos/Dockerfile
@@ -11,19 +11,19 @@ COPY kong.rpm /tmp/kong.rpm
 ARG KONG_VERSION=2.1.3
 ENV KONG_VERSION $KONG_VERSION
 
-ARG KONG_SHA256="be97835859ca05de3db5144bb59c8bdd4e46bd7a65fdd5f7ec500cb445eb62e3"
+ARG KONG_SHA256="c39e596ac3aac771377fc67eb4fb151216daeba6e8b1595c670e8c571b5cd3a0"
 
 RUN set -ex; \
 	if [ "$ASSET" = "ce" ] ; then \
 		curl -fL "https://bintray.com/kong/kong-rpm/download_file?file_path=centos/7/kong-$KONG_VERSION.el7.amd64.rpm" -o /tmp/kong.rpm \
 		&& echo "$KONG_SHA256  /tmp/kong.rpm" | sha256sum -c -; \
 	fi; \
-	yum install -y -q unzip shadow-utils git zlib zlib-devel \
+	yum install -y -q unzip shadow-utils git \
 	&& yum clean all -q \
 	&& rm -fr /var/cache/yum/* /tmp/yum_save*.yumtx /root/.pki \
 	&& useradd kong \
 	&& mkdir -p "/usr/local/kong" \
-	&& yum install -y /tmp/kong.rpm \
+	&& yum --nogpgcheck localinstall -y /tmp/kong.rpm \
 	&& yum clean all \
 	&& rm /tmp/kong.rpm \
 	&& chown -R kong:0 /usr/local/kong \

--- a/rhel/Dockerfile
+++ b/rhel/Dockerfile
@@ -22,7 +22,7 @@ COPY kong.rpm /tmp/kong.rpm
 ARG KONG_VERSION=2.1.3
 ENV KONG_VERSION $KONG_VERSION
 
-ARG KONG_SHA256="615a05a527c98832797858665477726fa164792063b104318d6b0695dbf1e4bc"
+ARG KONG_SHA256="83ca640bfd67ae00e103603db269ab0e4dfd0fbcc87b413086c26d09b11c3477"
 ENV KONG_SHA256 $KONG_SHA256
 
 RUN set -ex; \
@@ -30,7 +30,7 @@ RUN set -ex; \
         curl -fL "https://bintray.com/kong/kong-rpm/download_file?file_path=rhel/7/kong-$KONG_VERSION.rhel7.amd64.rpm" -o /tmp/kong.rpm \
         && echo "$KONG_SHA256  /tmp/kong.rpm" | sha256sum -c -; \
     fi; \
-    yum install -y -q unzip shadow-utils zlib zlib-devel \
+    yum install -y -q unzip shadow-utils \
 	&& yum clean all -q \
 	&& rm -fr /var/cache/yum/* /tmp/yum_save*.yumtx /root/.pki \
 	&& useradd kong \

--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -11,18 +11,15 @@ ARG KONG_VERSION=2.1.3
 ENV KONG_VERSION $KONG_VERSION
 
 RUN set -ex; \
+    apt-get update && \
     if [ "$ASSET" = "ce" ] ; then \
-        apt-get update && \
         apt-get install -y curl && \
         curl -fL "https://bintray.com/kong/kong-deb/download_file?file_path=kong-$KONG_VERSION.xenial.$(dpkg --print-architecture).deb" -o /tmp/kong.deb \
         && apt-get purge -y curl; \
     fi; \
-    apt-get update \
-    && apt-get install -y --no-install-recommends perl unzip git \
-    && { apt-get install -y --no-install-recommends zlibc || true; } \
-    && { apt-get install -y --no-install-recommends zlib1g-dev || true; } \
-    && rm -rf /var/lib/apt/lists/* \
-	&& dpkg -i /tmp/kong.deb \
+    apt-get install -y --no-install-recommends unzip git \
+	&& apt install --yes /tmp/kong.deb \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /tmp/kong.deb \
 	&& useradd -ms /bin/bash kong \
     && mkdir -p "/usr/local/kong" \


### PR DESCRIPTION
fpm marks the zlib dependencies therefore it shouldn't be necessary to duplicate that logic in our Dockerfiles