### PR TITLE
chore(tests) use the kong source that matches the version we built

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-KONG_BUILD_TOOLS?=4.8.0
+KONG_BUILD_TOOLS?=4.10.1
 BASE?=centos
 
 build:

--- a/tests/image.test.sh
+++ b/tests/image.test.sh
@@ -110,7 +110,7 @@ function run_test {
 
   git clone https://github.com/Kong/kong.git || true
   pushd kong
-  git checkout 2.1.0-beta.1
+  git checkout $version_given
   popd
 
   pushd kong-build-tools

--- a/tests/image.test.sh
+++ b/tests/image.test.sh
@@ -110,7 +110,7 @@ function run_test {
 
   git clone https://github.com/Kong/kong.git || true
   pushd kong
-  git checkout $version_given
+  git checkout $version_given || git checkout next
   popd
 
   pushd kong-build-tools


### PR DESCRIPTION
Edit to add: there's no historic case defaulting to next would not have worked.

We clone the kong source so we have access to the `.requirements` file.

The requirements file is needed by kong-build-tools to double check the right things got built. However, running the  [01-package test suite](https://github.com/Kong/kong-build-tools/tree/master/test/tests/01-package) on docker-kong CI is largely unecessary (with the exception of the version check as it has been beneficial in the past) as any asset couldn't have been built without already going through the tests.

I think this initially got pinned to `2.1.0-beta.1` because the `$version_given` variable is incorrect for our prereleases.

Future improvements:
- only run the [02-api test suite](https://github.com/Kong/kong-build-tools/tree/master/test/tests/02-api) against docker-kong
- logic to handle pre release tag format. In the absence of a tag default to `next` might be OK
- possibly merge kbt and docker-kong. They're becoming rather intertwined