### PR TITLE
chore(*) protect against error with the useradd instruction

### DIFF
--- a/centos/Dockerfile
+++ b/centos/Dockerfile
@@ -21,7 +21,6 @@ RUN set -ex; \
   yum install -y -q unzip shadow-utils git \
   && yum clean all -q \
   && rm -fr /var/cache/yum/* /tmp/yum_save*.yumtx /root/.pki \
-  && useradd kong \
   && mkdir -p "/usr/local/kong" \
   # Please update the centos install docs if the below line is changed so that
   # end users can properly install Kong along with its required dependencies

--- a/rhel/Dockerfile
+++ b/rhel/Dockerfile
@@ -33,7 +33,6 @@ RUN set -ex; \
     yum install -y -q unzip shadow-utils \
     && yum clean all -q \
     && rm -fr /var/cache/yum/* /tmp/yum_save*.yumtx /root/.pki \
-    && useradd kong \
     && mkdir -p "/usr/local/kong" \
     # Please update the rhel install docs if the below line is changed so that
     # end users can properly install Kong along with its required dependencies

--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -25,7 +25,6 @@ RUN set -ex; \
     && apt install --yes /tmp/kong.deb \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /tmp/kong.deb \
-    && useradd -ms /bin/bash kong \
     && mkdir -p "/usr/local/kong" \
     && chown -R kong:0 /usr/local/kong \
     && chown kong:0 /usr/local/bin/kong \


### PR DESCRIPTION
The 'kong' user should now be already created on package creation [1].

The `chown` and `chmod` commands are unchanged because these are
specific commands needed to run Kong on OpenShift [2].

[1] https://github.com/Kong/kong-build-tools/pull/339
[2] https://github.com/Kong/docker-kong/pull/243/