### PR TITLE
fix(useradd) migrating useradd to after-isntall.sh

### DIFF
--- a/centos/Dockerfile
+++ b/centos/Dockerfile
@@ -21,7 +21,7 @@ RUN set -ex; \
   yum install -y -q unzip shadow-utils git \
   && yum clean all -q \
   && rm -fr /var/cache/yum/* /tmp/yum_save*.yumtx /root/.pki \
-  && useradd kong \
+  && useradd kong || true \
   && mkdir -p "/usr/local/kong" \
   # Please update the centos install docs if the below line is changed so that
   # end users can properly install Kong along with its required dependencies

--- a/rhel/Dockerfile
+++ b/rhel/Dockerfile
@@ -33,7 +33,7 @@ RUN set -ex; \
     yum install -y -q unzip shadow-utils \
     && yum clean all -q \
     && rm -fr /var/cache/yum/* /tmp/yum_save*.yumtx /root/.pki \
-    && useradd kong \
+    && useradd kong || true \
     && mkdir -p "/usr/local/kong" \
     # Please update the rhel install docs if the below line is changed so that
     # end users can properly install Kong along with its required dependencies

--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -25,7 +25,7 @@ RUN set -ex; \
     && apt install --yes /tmp/kong.deb \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /tmp/kong.deb \
-    && useradd -ms /bin/bash kong \
+    && useradd -ms /bin/bash kong || true \
     && mkdir -p "/usr/local/kong" \
     && chown -R kong:0 /usr/local/kong \
     && chown kong:0 /usr/local/bin/kong \


### PR DESCRIPTION
During the migration there's a window where the Kong asset may / may not try to `useradd`. We'll allow failures for a period of time but in a future version remove the `useradd` entirely from our docker images