### PR TITLE
fix(tests) dont double test our packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,10 @@ services:
 
 env:
   matrix:
-    - BASE="centos" KONG_DOCKER_TAG="kong-centos"
-    - BASE="alpine" KONG_DOCKER_TAG="kong-alpine"
-    - BASE="ubuntu" KONG_DOCKER_TAG="kong-ubuntu"
-    - BASE="rhel" KONG_DOCKER_TAG="kong-rhel"
+    - BASE="centos" KONG_DOCKER_TAG="kong-centos" PACKAGE_TYPE="rpm"
+    - BASE="alpine" KONG_DOCKER_TAG="kong-alpine" PACKAGE_TYPE="apk"
+    - BASE="ubuntu" KONG_DOCKER_TAG="kong-ubuntu" PACKAGE_TYPE="deb"
+    - BASE="rhel" KONG_DOCKER_TAG="kong-rhel" PACKAGE_TYPE="rpm"
 
 before_script:
   - sudo apt-get install figlet

--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -71,9 +71,9 @@ services:
       - kong-net
     ports:
       - "8000:8000/tcp"
-      - "127.0.0.1:8001:8001/tcp"
+      - "8001:8001/tcp"
       - "8443:8443/tcp"
-      - "127.0.0.1:8444:8444/tcp"
+      - "8444:8444/tcp"
     healthcheck:
       test: ["CMD", "kong", "health"]
       interval: 10s

--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -71,9 +71,9 @@ services:
       - kong-net
     ports:
       - "8000:8000/tcp"
-      - "8001:8001/tcp"
+      - "127.0.0.1:8001:8001/tcp"
       - "8443:8443/tcp"
-      - "8444:8444/tcp"
+      - "127.0.0.1:8444:8444/tcp"
     healthcheck:
       test: ["CMD", "kong", "health"]
       interval: 10s

--- a/tests/01-image.test.sh
+++ b/tests/01-image.test.sh
@@ -114,7 +114,7 @@ function run_test {
   popd
 
   pushd kong-build-tools
-  rm -rf test/tests/03-go-plugins
+  rm -rf test/tests/01-package
   docker tag kong-$BASE $BASE:$BASE
   KONG_VERSION=$version_given KONG_TEST_IMAGE_NAME=kong-$BASE RESTY_IMAGE_BASE=$BASE RESTY_IMAGE_TAG=$BASE make test
   if [ $? -eq 0 ]; then

--- a/tests/01-image.test.sh
+++ b/tests/01-image.test.sh
@@ -49,7 +49,7 @@ function run_test {
   done
 
   sleep 20
-  curl -I localhost:8001 | grep 'Server: openresty'
+  curl -I localhost:8001 | grep -E '(openresty|kong)'
   if [ $? -eq 0 ]; then
     tsuccess
   else
@@ -115,7 +115,8 @@ function run_test {
 
   pushd kong-build-tools
   rm -rf test/tests/03-go-plugins
-  KONG_VERSION=$version_given KONG_TEST_IMAGE_NAME=kong-$BASE RESTY_IMAGE_TAG=$BASE make test
+  docker tag kong-$BASE $BASE:$BASE
+  KONG_VERSION=$version_given KONG_TEST_IMAGE_NAME=kong-$BASE RESTY_IMAGE_BASE=$BASE RESTY_IMAGE_TAG=$BASE make test
   if [ $? -eq 0 ]; then
     tsuccess
   else

--- a/tests/01-image.test.sh
+++ b/tests/01-image.test.sh
@@ -31,7 +31,7 @@ function run_test {
   pushd compose
   docker swarm init
   KONG_DOCKER_TAG=kong:1.5.0 docker stack deploy -c<(curl -fsSL https://raw.githubusercontent.com/Kong/docker-kong/1.5.0/swarm/docker-compose.yml) kong
-  until docker ps | grep kong:1.5.0 | grep -q healthy;  do
+  until docker ps -f health=healthy | grep -q kong:1.5.0;  do
     docker stack ps kong
     docker service ps kong_kong
     sleep 20
@@ -42,7 +42,7 @@ function run_test {
   sed -i -e 's/127.0.0.1://g' docker-compose.yml
   KONG_DOCKER_TAG=${KONG_DOCKER_TAG} docker stack deploy -c docker-compose.yml kong
   sleep 20
-  until docker ps | grep ${KONG_DOCKER_TAG}:latest | grep -q healthy; do
+  until docker ps -f health=healthy | grep -q ${KONG_DOCKER_TAG}:latest; do
     docker stack ps kong
     docker service ps kong_kong
     sleep 20


### PR DESCRIPTION
kbt tests run the 01 packaging tests then put the assets onto bintray
docker-kong Dockerfile's pull said assets from bintray

let's not re-run the KBT packaging tests. The KBT api tests still has use so going to keep it