### PR TITLE
feat(customize) allow rocks with C-code (self contained)

### DIFF
--- a/customize/packer.lua
+++ b/customize/packer.lua
@@ -54,6 +54,8 @@ local platforms = {
       "apk add git",
       "apk add wget",
       "apk add zip",
+      "apk add gcc",
+      "apk add musl-dev",
     },
     target_commands = {       -- run before installing in the target image
     },
@@ -63,6 +65,7 @@ local platforms = {
       "yum -y install git",
       "yum -y install unzip",
       "yum -y install zip",
+      "yum -y install gcc gcc-c++ make",
     },
     target_commands = {       -- run before installing in the target image
       "yum -y install unzip",
@@ -73,6 +76,7 @@ local platforms = {
       "apt update",
       "apt install -y zip",
       "apt install -y wget",
+      "apt install -y build-essential",
     },
     target_commands = {       -- run before installing in the target image
     },

--- a/tests/02-customize.test.sh
+++ b/tests/02-customize.test.sh
@@ -62,8 +62,26 @@ function run_test {
 
   tchapter "Customize $BASE"
 
-  ttest "injects a plugin"
+  ttest "injects a plugin, pure-Lua"
   local test_plugin_name="kong-upstream-jwt"
+  build_custom_image "$test_plugin_name"
+  if [ ! $? -eq 0 ]; then
+    tfailure
+  else
+    run_kong_cmd "luarocks list --porcelain" | grep $test_plugin_name
+    if [ ! $? -eq 0 ]; then
+      tmessage "injected plugin '$test_plugin_name' was not found"
+      tfailure
+    else
+      tsuccess
+    fi
+  fi
+  delete_custom_image
+
+
+
+  ttest "injects a plugin, with self-contained C code (no binding)"
+  local test_plugin_name="lua-protobuf"
   build_custom_image "$test_plugin_name"
   if [ ! $? -eq 0 ]; then
     tfailure


### PR DESCRIPTION
Besides customizing Kong images by adding pure-Lua plugins in a docker image, this allows to also add plugins/rocks that have c-code. Luarocks makes it sooooo easy, just pack'em and ship'em.

Just rocks that bind to an existing library cannot be added yet, since we have no means of first adding that library yet.