### PR TITLE
bump alpine image to 3.13

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.11
+FROM alpine:3.13
 
 LABEL maintainer="Kong <support@konghq.com>"
 


### PR DESCRIPTION
Hello,

We would like to use some native packages that are not available in Alpine 3.11.

Also, it is possible to include this change into Kong v2.3.x?

Thank you!