### PR TITLE
fix(ci) `docker login` to increase hub rate limit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ env:
 before_script:
   - sudo apt-get install figlet
   - make build
+  - echo "$DOCKER_KEY" | docker login -u "$DOCKER_USER" --password-stdin
 script:
   - make test
 


### PR DESCRIPTION
CI failures like https://travis-ci.com/github/Kong/docker-kong/jobs/505026062 became very common recently; logging in should ameliorate the state of affairs.