### PR TITLE
fix(alpine) create a system kong group

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -38,6 +38,7 @@ RUN set -eux; \
     && rm -rf /kong \
     && apk add --no-cache libstdc++ libgcc openssl pcre perl tzdata libcap zip bash zlib zlib-dev git ca-certificates \
     && adduser -S kong \
+    && addgroup -S kong \
     && mkdir -p "/usr/local/kong" \
     && chown -R kong:0 /usr/local/kong \
     && chown kong:0 /usr/local/bin/kong \


### PR DESCRIPTION
https://docs.konghq.com/enterprise/2.4.x/property-reference/#nginx_user

> Note: If the kong user and the kong group are not available, the default user and group credentials will be nobody nobody.

We must create a kong group so that the default `nginx_user` is used. This is already the case in Docker CentOS, for example, but not in Alpine.

Alpine:
```
$ id
uid=100(kong) gid=65533(nogroup) groups=65533(nogroup)
```

CentOS:
```
$ id
uid=1000(kong) gid=1000(kong) groups=1000(kong)
```