### PR TITLE
CPUs should be string, not int

### DIFF
--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -109,7 +109,7 @@ services:
         window: 10s
       resources:
         limits:
-          cpus: ${KONG_CPU_LIMIT:-2}
+          cpus: "${KONG_CPU_LIMIT:-2}"
           memory: ${KONG_MEMORY_LIMIT:-2g}
     security_opt:
       - no-new-privileges


### PR DESCRIPTION
Fixes this issue when trying `docker-compose up`:
`* 'Deploy.Resources.Limits.cpus' expected type 'string', got unconvertible type 'int', value: '2'`