### PR TITLE
chore(automation) ensure `submit.sh` correctly adds minor versions

### DIFF
--- a/submit.sh
+++ b/submit.sh
@@ -166,7 +166,7 @@ then
         v = "'$version'"
         xy = "'$xy'"
         commit = "'$commit'"
-        print "Tags: " v "-alpine, " v
+        print "Tags: " v "-alpine, " v ", " xy ", alpine"
         print "GitCommit: " commit
         print "GitFetch: refs/tags/" v
         print "Directory: alpine"
@@ -226,22 +226,24 @@ then
         print "Directory: alpine"
         print "Architectures: amd64"
         print ""
-        print "Tags: " v "-ubuntu, " xy "-ubuntu"
+        print "Tags: " v "-ubuntu, " xy "-ubuntu, ubuntu"
         print "GitCommit: " commit
         print "GitFetch: refs/tags/" v
         print "Directory: ubuntu"
         print "Architectures: amd64, arm64v8"
         print ""
-        print "Tags: " v "-centos, " xy "-centos"
+        print "Tags: " v "-centos, " xy "-centos, centos"
         print "GitCommit: " commit
         print "GitFetch: refs/tags/" v
-        print "Constraints: !aufs"
         print "Directory: centos"
         print "Architectures: amd64"
         print ""
         before_first = 0
       } else if (!(in_rc_tag == 1)) {
         gsub(", latest", "")
+        gsub(", alpine", "")
+        gsub(", ubuntu", "")
+        gsub(", centos", "")
         print
       }
       if (reset == 1) {


### PR DESCRIPTION
Ensure `submit.sh` properly adds distro labels for minor releases - and removes said labels from old images.

```
Maintainers: Kong Docker Maintainers <support@konghq.com> (@thekonginc)
GitRepo: https://github.com/Kong/docker-kong.git
# needs "Constraints" to match "centos" (which this image is "FROM")

Tags: 2.6.0-alpine, 2.6.0, 2.6, latest
GitCommit: foo
GitFetch: refs/tags/2.6.0
Directory: alpine
Architectures: amd64

Tags: 2.6.0-ubuntu, 2.6-ubuntu, ubuntu
GitCommit: foo
GitFetch: refs/tags/2.6.0
Directory: ubuntu
Architectures: amd64, arm64v8

Tags: 2.6.0-centos, 2.6-centos, centos
GitCommit: foo
GitFetch: refs/tags/2.6.0
Directory: centos
Architectures: amd64

Tags: 2.5.0-alpine, 2.5.0, 2.5
GitCommit: ff3efa2c53e785e655a9c7de24c8111a373900cb
GitFetch: refs/tags/2.5.0
Directory: alpine
Architectures: amd64

Tags: 2.5.0-ubuntu, 2.5-ubuntu
GitCommit: ff3efa2c53e785e655a9c7de24c8111a373900cb
GitFetch: refs/tags/2.5.0
Directory: ubuntu
Architectures: amd64, arm64v8

Tags: 2.5.0-centos, 2.5-centos
GitCommit: ff3efa2c53e785e655a9c7de24c8111a373900cb
GitFetch: refs/tags/2.5.0
Directory: centos
Architectures: amd64
```