### PR TITLE
chore(automation) add arm64v8 tag to automation

### DIFF
--- a/submit.sh
+++ b/submit.sh
@@ -224,7 +224,7 @@ then
         print "GitCommit: " commit
         print "GitFetch: refs/tags/" v
         print "Directory: alpine"
-        print "Architectures: amd64"
+        print "Architectures: amd64, arm64v8"
         print ""
         print "Tags: " v "-ubuntu, " xy "-ubuntu, ubuntu"
         print "GitCommit: " commit


### PR DESCRIPTION
Ensure major releases automation adds arm64 tag to alpine image. Will help avoid issues like https://github.com/docker-library/official-images/pull/10737 in the future.