### PR TITLE
chore(submit) avoid dupe previous version tags

### DIFF
--- a/submit.sh
+++ b/submit.sh
@@ -185,7 +185,6 @@ then
         print "Directory: centos"
         print "Architectures: amd64"
         print ""
-        print
         before_first = 0
       } else {
         print
@@ -238,7 +237,6 @@ then
         print "Directory: centos"
         print "Architectures: amd64"
         print ""
-        print
         before_first = 0
       }
       if (!(in_rc_tag == 1)) {


### PR DESCRIPTION
Previously, the output would be:
```
diff --git a/library/kong b/library/kong
index 7b1cdf413..c4198b673 100644
--- a/library/kong
+++ b/library/kong
@@ -20,6 +20,24 @@ GitFetch: refs/tags/2.6.0
 Directory: centos
 Architectures: amd64
 
+Tags: 2.6.0-alpine, 2.6.0, 2.6
+GitCommit: 76ba9c46dd932e518016d48a8414d7af185c2a76
+GitFetch: refs/tags/2.6.0
+Directory: alpine
+Architectures: amd64, arm64v8
+
+Tags: 2.6.0-ubuntu, 2.6-ubuntu
+GitCommit: 76ba9c46dd932e518016d48a8414d7af185c2a76
+GitFetch: refs/tags/2.6.0
+Directory: ubuntu
+Architectures: amd64, arm64v8
+
+Tags: 2.6.0-centos, 2.6-centos
+GitCommit: 76ba9c46dd932e518016d48a8414d7af185c2a76
+GitFetch: refs/tags/2.6.0
+Directory: centos
+Architectures: amd64
+
+ Tags: 2.5.1-alpine, 2.5.1, 2.5
Tags: 2.5.1-alpine, 2.5.1, 2.5, alpine, latest
 GitCommit: 7b610b2e566274d70aed60dd3f10a8e43fe91fb4
 GitFetch: refs/tags/2.5.1
```

Notice the duplicated line for 2.5.1 alpine.