### PR TITLE
fix(centos) allow version build argument and fix package download [FT-2019]

### DIFF
--- a/centos/Dockerfile
+++ b/centos/Dockerfile
@@ -1,5 +1,8 @@
-FROM centos:8
+ARG CENTOS_VERSION=8
+FROM centos:$CENTOS_VERSION
 LABEL maintainer="Kong <support@konghq.com>"
+
+ARG CENTOS_VERSION
 
 ARG ASSET=ce
 ENV ASSET $ASSET
@@ -11,13 +14,15 @@ COPY kong.rpm /tmp/kong.rpm
 ARG KONG_VERSION=2.6.0
 ENV KONG_VERSION $KONG_VERSION
 
-ARG KONG_SHA256="f83a1030b01aa3deb4535394b550228f4804a6fd35a4ea4b11e12dcbcacdadc0"
+ARG KONG_SHA256_7="f83a1030b01aa3deb4535394b550228f4804a6fd35a4ea4b11e12dcbcacdadc0"
+ARG KONG_SHA256_8="95422738b65f8700823bf873bedab695973b17e3b67a117e524aeaa55d09f043"
 
 # hadolint ignore=DL3033
 RUN set -ex; \
     if [ "$ASSET" = "ce" ] ; then \
-      curl -fL https://download.konghq.com/gateway-${KONG_VERSION%%.*}.x-centos-7/Packages/k/kong-$KONG_VERSION.el7.amd64.rpm -o /tmp/kong.rpm \
-      && echo "$KONG_SHA256  /tmp/kong.rpm" | sha256sum -c -; \
+      export KONG_SHA256="KONG_SHA256_$CENTOS_VERSION" \
+      && curl -fL https://download.konghq.com/gateway-${KONG_VERSION%%.*}.x-centos-$CENTOS_VERSION/Packages/k/kong-$KONG_VERSION.el$CENTOS_VERSION.amd64.rpm -o /tmp/kong.rpm \
+      && echo "${!KONG_SHA256}  /tmp/kong.rpm" | sha256sum -c -; \
     fi; \
     yum install -y -q unzip shadow-utils git \
     && yum clean all -q \


### PR DESCRIPTION
This change allows for `--build-arg CENTOS_VERSION=#` to be passed in which allows for building CentOS 7 or 8 docker images. It also addresses an issue where the CentOS 7 artifact is used for CentOS 8 instances.

**Note**: For 2.5.1 and 2.6.0 the CentOS 7 artifact was installed on CentOS 8 docker images.

## Validation

### CentOS 8 (default)

```
(
  cd centos
  docker build -t centos8-test .
)
docker run centos8-test cat /etc/centos-release
```

#### Output

##### Build snippet

```
Step 13/20 : RUN set -ex;     if [ "$ASSET" = "ce" ] ; then       export KONG_SHA256="KONG_SHA256_$CENTOS_VERSION"       && curl -fL https://download.konghq.com/gateway-${KONG_VERSION%%.*}.x-centos-$CENTOS_VERSION/Packages/k/kong-$KONG_VERSION.el$CENTOS_VERSION.amd64.rpm -o /tmp/kong.rpm       && echo "${!KONG_SHA256}  /tmp/kong.rpm" | sha256sum -c -;     fi;     yum install -y -q unzip shadow-utils git     && yum clean all -q     && rm -fr /var/cache/yum/* /tmp/yum_save*.yumtx /root/.pki     && yum install -y /tmp/kong.rpm     && yum clean all     && rm /tmp/kong.rpm     && chown kong:0 /usr/local/bin/kong     && chown -R kong:0 /usr/local/kong     && ln -s /usr/local/openresty/bin/resty /usr/local/bin/resty     && ln -s /usr/local/openresty/luajit/bin/luajit /usr/local/bin/luajit     && ln -s /usr/local/openresty/luajit/bin/luajit /usr/local/bin/lua     && ln -s /usr/local/openresty/nginx/sbin/nginx /usr/local/bin/nginx     && if [ "$ASSET" = "ce" ] ; then       kong version ;     fi
 ---> Running in 0de91df3afb0
+ '[' ce = ce ']'
+ export KONG_SHA256=KONG_SHA256_8
+ KONG_SHA256=KONG_SHA256_8
+ curl -fL https://download.konghq.com/gateway-2.x-centos-8/Packages/k/kong-2.6.0.el8.amd64.rpm -o /tmp/kong.rpm
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    10  100    10    0     0     37      0 --:--:-- --:--:-- --:--:--    36
100 30.5M  100 30.5M    0     0  4471k      0  0:00:06  0:00:06 --:--:-- 4977k
+ echo '95422738b65f8700823bf873bedab695973b17e3b67a117e524aeaa55d09f043  /tmp/kong.rpm'
```

##### OS information

```
CentOS Linux release 8.4.2105
```

### CentOS 7 (override)

```
(
  cd centos
  docker build --build-arg CENTOS_VERSION=7 -t centos7-test .
)
docker run centos7-test cat /etc/centos-release
```

#### Output

##### Build snippet

```
Step 13/20 : RUN set -ex;     if [ "$ASSET" = "ce" ] ; then       export KONG_SHA256="KONG_SHA256_$CENTOS_VERSION"       && curl -fL https://download.konghq.com/gateway-${KONG_VERSION%%.*}.x-centos-$CENTOS_VERSION/Packages/k/kong-$KONG_VERSION.el$CENTOS_VERSION.amd64.rpm -o /tmp/kong.rpm       && echo "${!KONG_SHA256}  /tmp/kong.rpm" | sha256sum -c -;     fi;     yum install -y -q unzip shadow-utils git     && yum clean all -q     && rm -fr /var/cache/yum/* /tmp/yum_save*.yumtx /root/.pki     && yum install -y /tmp/kong.rpm     && yum clean all     && rm /tmp/kong.rpm     && chown kong:0 /usr/local/bin/kong     && chown -R kong:0 /usr/local/kong     && ln -s /usr/local/openresty/bin/resty /usr/local/bin/resty     && ln -s /usr/local/openresty/luajit/bin/luajit /usr/local/bin/luajit     && ln -s /usr/local/openresty/luajit/bin/luajit /usr/local/bin/lua     && ln -s /usr/local/openresty/nginx/sbin/nginx /usr/local/bin/nginx     && if [ "$ASSET" = "ce" ] ; then       kong version ;     fi
 ---> Running in dc9d67ef14db
+ '[' ce = ce ']'
+ export KONG_SHA256=KONG_SHA256_7
+ KONG_SHA256=KONG_SHA256_7
+ curl -fL https://download.konghq.com/gateway-2.x-centos-7/Packages/k/kong-2.6.0.el7.amd64.rpm -o /tmp/kong.rpm
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    10  100    10    0     0     23      0 --:--:-- --:--:-- --:--:--    23
100 24.4M  100 24.4M    0     0  4492k      0  0:00:05  0:00:05 --:--:-- 5361k
+ echo 'f83a1030b01aa3deb4535394b550228f4804a6fd35a4ea4b11e12dcbcacdadc0  /tmp/kong.rpm'
```

##### OS information

```
CentOS Linux release 7.9.2009 (Core)
```