### PR TITLE
feat(alpine) add protobuf-dev dependency

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -38,7 +38,7 @@ RUN set -eux; \
     && mv /kong/usr/local/* /usr/local \
     && mv /kong/etc/* /etc \
     && rm -rf /kong \
-    && apk add --no-cache libstdc++ libgcc openssl pcre perl tzdata libcap zip bash zlib zlib-dev git ca-certificates \
+    && apk add --no-cache libstdc++ libgcc openssl pcre perl tzdata libcap zip bash zlib zlib-dev git ca-certificates protobuf-dev \
     && adduser -S kong \
     && addgroup -S kong \
     && mkdir -p "/usr/local/kong" \


### PR DESCRIPTION
It's required by Kong's external plugins using protobuf-based
protocol.

Dependency for other packages is added in https://github.com/Kong/kong-build-tools/pull/409.