### PR TITLE
fix(customize) sets permissions in line with Kong install

### DIFF
--- a/customize/packer.lua
+++ b/customize/packer.lua
@@ -423,6 +423,14 @@ fi
 %s
 %s
 
+# set ownership to kong user/group
+find /usr/local/share/lua/5.1/          -type f -exec chown 1000:1000 "{}" +
+find /usr/local/share/lua/5.1/          -type d -exec chown 1000:1000 "{}" +
+find /usr/local/lib/lua/5.1/            -type f -exec chown 1000:1000 "{}" +
+find /usr/local/lib/lua/5.1/            -type d -exec chown 1000:1000 "{}" +
+find /usr/local/lib/luarocks/rocks-5.1/ -type f -exec chown 1000:1000 "{}" +
+find /usr/local/lib/luarocks/rocks-5.1/ -type d -exec chown 1000:1000 "{}" +
+
 # clean up by deleting all the temporary stuff
 rm -rf /plugins
 ]=]


### PR DESCRIPTION
When using the `customize` feature, anything installed will be owned by `root`. This updates the files to be identically owned as the original Kong installed plugins.

Here's after a customize run (the readme example), installing 2 plugins:
```shell
s$ docker run -it --rm kong_custom /bin/bash
bash-5.1$ cd /usr/local/share/lua/5.1/kong/plugins
bash-5.1$ ls -la
total 172
drwxr-xr-x    1 1000     1000          4096 Nov 16 12:25 .
drwxr-xr-x    1 1000     1000          4096 Nov 13 05:49 ..
drwxr-xr-x    3 1000     1000          4096 Nov 13 05:49 acl
drwxr-xr-x    4 1000     1000          4096 Nov 13 05:49 acme
drwxr-xr-x    2 1000     1000          4096 Nov 13 05:49 aws-lambda
drwxr-xr-x    2 1000     1000          4096 Nov 13 05:49 azure-functions
-rw-r--r--    1 1000     1000          1288 Sep 28 18:54 base_plugin.lua
drwxr-xr-x    3 1000     1000          4096 Nov 13 05:49 basic-auth
drwxr-xr-x    3 1000     1000          4096 Nov 13 05:49 bot-detection
drwxr-xr-x    2 1000     1000          4096 Nov 13 05:49 correlation-id
drwxr-xr-x    2 1000     1000          4096 Nov 13 05:49 cors
drwxr-xr-x    2 1000     1000          4096 Nov 13 05:49 datadog
drwxr-xr-x    2 1000     1000          4096 Nov 13 05:49 file-log
drwxr-xr-x    2 1000     1000          4096 Nov 13 05:49 grpc-gateway
drwxr-xr-x    2 1000     1000          4096 Nov 13 05:49 grpc-web
drwxr-xr-x    3 1000     1000          4096 Nov 13 05:49 hmac-auth
drwxr-xr-x    2 1000     1000          4096 Nov 13 05:49 http-log
drwxr-xr-x    2 root     root          4096 Nov 16 12:25 http-to-https
drwxr-xr-x    3 1000     1000          4096 Nov 13 05:49 ip-restriction
drwxr-xr-x    3 1000     1000          4096 Nov 13 05:49 jwt
drwxr-xr-x    3 1000     1000          4096 Nov 13 05:49 key-auth
drwxr-xr-x    2 root     root          4096 Nov 16 12:25 kong-upstream-jwt
drwxr-xr-x    2 1000     1000          4096 Nov 13 05:49 ldap-auth
drwxr-xr-x    2 1000     1000          4096 Nov 13 05:49 log-serializers
drwxr-xr-x    2 1000     1000          4096 Nov 13 05:49 loggly
drwxr-xr-x    4 1000     1000          4096 Nov 13 05:49 oauth2
drwxr-xr-x    2 1000     1000          4096 Nov 13 05:49 post-function
drwxr-xr-x    2 1000     1000          4096 Nov 13 05:49 pre-function
drwxr-xr-x    3 1000     1000          4096 Nov 13 05:49 prometheus
drwxr-xr-x    3 1000     1000          4096 Nov 13 05:49 proxy-cache
drwxr-xr-x    4 1000     1000          4096 Nov 13 05:49 rate-limiting
drwxr-xr-x    2 1000     1000          4096 Nov 13 05:49 request-size-limiting
drwxr-xr-x    2 1000     1000          4096 Nov 13 05:49 request-termination
drwxr-xr-x    3 1000     1000          4096 Nov 13 05:49 request-transformer
drwxr-xr-x    4 1000     1000          4096 Nov 13 05:49 response-ratelimiting
drwxr-xr-x    2 1000     1000          4096 Nov 13 05:49 response-transformer
drwxr-xr-x    4 1000     1000          4096 Nov 13 05:49 session
drwxr-xr-x    2 1000     1000          4096 Nov 13 05:49 statsd
drwxr-xr-x    2 1000     1000          4096 Nov 13 05:49 syslog
drwxr-xr-x    2 1000     1000          4096 Nov 13 05:49 tcp-log
drwxr-xr-x    2 1000     1000          4096 Nov 13 05:49 udp-log
drwxr-xr-x    2 1000     1000          4096 Nov 13 05:49 zipkin
bash-5.1$
```
