### PR TITLE
fix(centos): centos hacks so we can continue to build for customers that require these

### DIFF
--- a/centos/Dockerfile
+++ b/centos/Dockerfile
@@ -15,6 +15,8 @@ ARG KONG_SHA256="d3769c15297d1b1b20cf684792a664ac851977b2c466f2776f2ae705708539e
 
 # hadolint ignore=DL3033
 RUN set -ex; \
+    sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-Linux-*; \
+    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Linux-*; \
     if [ "$ASSET" = "ce" ] ; then \
       curl -fL https://download.konghq.com/gateway-${KONG_VERSION%%.*}.x-centos-8/Packages/k/kong-$KONG_VERSION.el8.amd64.rpm -o /tmp/kong.rpm \
       && echo "$KONG_SHA256  /tmp/kong.rpm" | sha256sum -c -; \


### PR DESCRIPTION
Solves for:
```
docker run --rm -v /var/cache/yum:/var/cache/yum -it centos:8 /bin/bash
[root@786d0bc5e1a6 /]# yum update
Failed to set locale, defaulting to C.UTF-8
CentOS Linux 8 - AppStream                                                                                                                                                                                                                                                                                                                                                                                                                                218  B/s |  38  B     00:00
Error: Failed to download metadata for repo 'appstream': Cannot prepare internal mirrorlist: No URLs in mirrorlist
```