### PR TITLE
fix(centos): kbt currently depends on the centos Dockerfile existing

### DIFF
--- a/centos/Dockerfile
+++ b/centos/Dockerfile
@@ -1,0 +1,57 @@
+FROM centos:8
+LABEL maintainer="Kong <support@konghq.com>"
+
+ARG ASSET=ce
+ENV ASSET $ASSET
+
+ARG EE_PORTS
+
+COPY kong.rpm /tmp/kong.rpm
+
+ARG KONG_VERSION=2.7.1
+ENV KONG_VERSION $KONG_VERSION
+
+ARG KONG_SHA256="d3769c15297d1b1b20cf684792a664ac851977b2c466f2776f2ae705708539e6"
+
+# hadolint ignore=DL3033
+RUN set -ex; \
+    if [ "$ASSET" = "ce" ] ; then \
+      curl -fL https://download.konghq.com/gateway-${KONG_VERSION%%.*}.x-centos-8/Packages/k/kong-$KONG_VERSION.el8.amd64.rpm -o /tmp/kong.rpm \
+      && echo "$KONG_SHA256  /tmp/kong.rpm" | sha256sum -c -; \
+    else \
+      # this needs to stay inside this "else" block so that it does not become part of the "official images" builds (https://github.com/docker-library/official-images/pull/11532#issuecomment-996219700)
+      yum update -y \
+      && yum upgrade -y ; \
+    fi; \
+    yum install -y -q unzip shadow-utils git \
+    && yum clean all -q \
+    && rm -fr /var/cache/yum/* /tmp/yum_save*.yumtx /root/.pki \
+    # Please update the centos install docs if the below line is changed so that
+    # end users can properly install Kong along with its required dependencies
+    # and that our CI does not diverge from our docs.
+    && yum install -y /tmp/kong.rpm \
+    && yum clean all \
+    && rm /tmp/kong.rpm \
+    && chown kong:0 /usr/local/bin/kong \
+    && chown -R kong:0 /usr/local/kong \
+    && ln -s /usr/local/openresty/bin/resty /usr/local/bin/resty \
+    && ln -s /usr/local/openresty/luajit/bin/luajit /usr/local/bin/luajit \
+    && ln -s /usr/local/openresty/luajit/bin/luajit /usr/local/bin/lua \
+    && ln -s /usr/local/openresty/nginx/sbin/nginx /usr/local/bin/nginx \
+    && if [ "$ASSET" = "ce" ] ; then \
+      kong version; \
+    fi
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+
+USER kong
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+
+EXPOSE 8000 8443 8001 8444 $EE_PORTS
+
+STOPSIGNAL SIGQUIT
+
+HEALTHCHECK --interval=10s --timeout=10s --retries=10 CMD kong health
+
+CMD ["kong", "docker-start"]

--- a/centos/docker-entrypoint.sh
+++ b/centos/docker-entrypoint.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -Eeo pipefail
+
+# usage: file_env VAR [DEFAULT]
+#    ie: file_env 'XYZ_DB_PASSWORD' 'example'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
+# "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
+file_env() {
+  local var="$1"
+  local fileVar="${var}_FILE"
+  local def="${2:-}"
+  # Do not continue if _FILE env is not set
+  if ! [ "${!fileVar:-}" ]; then
+    return
+  elif [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+    echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
+    exit 1
+  fi
+  local val="$def"
+  if [ "${!var:-}" ]; then
+    val="${!var}"
+  elif [ "${!fileVar:-}" ]; then
+    val="$(< "${!fileVar}")"
+  fi
+  export "$var"="$val"
+  unset "$fileVar"
+}
+
+export KONG_NGINX_DAEMON=${KONG_NGINX_DAEMON:=off}
+
+if [[ "$1" == "kong" ]]; then
+
+  all_kong_options="/usr/local/share/lua/5.1/kong/templates/kong_defaults.lua"
+  set +Eeo pipefail
+  while IFS='' read -r LINE || [ -n "${LINE}" ]; do
+      opt=$(echo "$LINE" | grep "=" | sed "s/=.*$//" | sed "s/ //" | tr '[:lower:]' '[:upper:]')
+      file_env "KONG_$opt"
+  done < $all_kong_options
+  set -Eeo pipefail
+
+  file_env KONG_PASSWORD
+  PREFIX=${KONG_PREFIX:=/usr/local/kong}
+
+  if [[ "$2" == "docker-start" ]]; then
+    kong prepare -p "$PREFIX" "$@"
+
+    ln -sf /dev/stdout $PREFIX/logs/access.log
+    ln -sf /dev/stdout $PREFIX/logs/admin_access.log
+    ln -sf /dev/stderr $PREFIX/logs/error.log
+
+    exec /usr/local/openresty/nginx/sbin/nginx \
+      -p "$PREFIX" \
+      -c nginx.conf
+  fi
+fi
+
+exec "$@"


### PR DESCRIPTION
kong-build-tools recycles the `centos/Dockerfile` for testing any rpm asset including amazonlinux2 for example.

Recreating the Dockerfile and entrypoint.sh but leaving this out of CI and out of our official docker library submissions so it doesn't cause release / ci failures

CI was previously setup [here](https://github.com/Kong/docker-kong/commit/c32a80c3dd332d096d1a6461d2816ead344d43c5#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88)
official submissions were previously setup [here](https://github.com/Kong/docker-kong/commit/c32a80c3dd332d096d1a6461d2816ead344d43c5#diff-0b3fd39710963fab4901895867a84a3589ed6c62d4d7493629ba44b581ff4653)
