### PR TITLE
feat(alpine) use alpine 3.16

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15
+FROM alpine:3.16
 
 LABEL maintainer="Kong <support@konghq.com>"
 


### PR DESCRIPTION
Notably, a bump in the busybox version:
```diff
diff -u <( syft alpine:3.15 2>&1 | sort ) <( syft alpine:3.16 2>&1 | sort )                                                                   1|0 ✔
--- /dev/fd/13	2022-05-24 10:48:00.064205143 -0700
+++ /dev/fd/14	2022-05-24 10:48:00.064902084 -0700
@@ -1,15 +1,15 @@
 NAME                    VERSION      TYPE
-alpine-baselayout       3.2.0-r18    apk
+alpine-baselayout       3.2.0-r20    apk
+alpine-baselayout-data  3.2.0-r20    apk
 alpine-keys             2.4-r1       apk
-apk-tools               2.12.7-r3    apk
-busybox                 1.34.1-r5    apk
+apk-tools               2.12.9-r3    apk
+busybox                 1.35.0-r13   apk
 ca-certificates-bundle  20211220-r0  apk
 libc-utils              0.7.2-r3     apk
-libcrypto1.1            1.1.1n-r0    apk
-libretls                3.3.4-r3     apk
-libssl1.1               1.1.1n-r0    apk
-musl                    1.2.2-r7     apk
-musl-utils              1.2.2-r7     apk
-scanelf                 1.3.3-r0     apk
-ssl_client              1.34.1-r5    apk
-zlib                    1.2.12-r0    apk
+libcrypto1.1            1.1.1o-r0    apk
+libssl1.1               1.1.1o-r0    apk
+musl                    1.2.3-r0     apk
+musl-utils              1.2.3-r0     apk
+scanelf                 1.3.4-r0     apk
+ssl_client              1.35.0-r13   apk
+zlib                    1.2.12-r1    apk
```