### PR TITLE
fix(config) removes platform from service

### DIFF
--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -52,7 +52,6 @@ services:
     restart: on-failure
 
   kong:
-    platform: linux/arm64
     image: "${KONG_DOCKER_TAG:-kong:latest}"
     user: "${KONG_USER:-kong}"
     environment:


### PR DESCRIPTION
Platform selection in docker-compose.yaml is preventing initialization on amd64 platforms.

Originated in PR #528 

Fixes #567 