### PR TITLE
fix(ubuntu) fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
-KONG_BUILD_TOOLS?=4.27.0
+# DO NOT update KONG_BUILD_TOOLS manually - it's set by update.sh
+# to ensure same version is used here and in the respective kong version
+KONG_BUILD_TOOLS?=4.25.3
 PACKAGE?=apk
 BASE?=alpine
 ASSET_LOCATION?=remote

--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -10,15 +10,21 @@ COPY kong.deb /tmp/kong.deb
 ARG KONG_VERSION=2.8.1
 ENV KONG_VERSION $KONG_VERSION
 
-ARG KONG_SHA256="10d12d23e5890414d666663094d51a42de41f8a9806fbc0baaf9ac4d37794361"
+ARG KONG_AMD64_SHA="10d12d23e5890414d666663094d51a42de41f8a9806fbc0baaf9ac4d37794361"
+ARG KONG_ARM64_SHA="61c13219ef64dac9aeae5ae775411e8cfcd406f068cf3e75d463f916ae6513cb"
 
 # hadolint ignore=DL3015
-RUN set -ex \
-    && apt-get update \
+RUN set -ex; \
+    arch=$(dpkg --print-architecture); \
+    case "${arch}" in \
+      amd64) KONG_SHA256=$KONG_AMD64_SHA ;; \
+      arm64) KONG_SHA256=$KONG_ARM64_SHA ;; \
+    esac; \
+    apt-get update \
     && if [ "$ASSET" = "ce" ] ; then \
       apt-get install -y curl \
       && UBUNTU_CODENAME=$(cat /etc/os-release | grep UBUNTU_CODENAME | cut -d = -f 2) \
-      && curl -fL https://download.konghq.com/gateway-${KONG_VERSION%%.*}.x-ubuntu-${UBUNTU_CODENAME}/pool/all/k/kong/kong_${KONG_VERSION}_amd64.deb -o /tmp/kong.deb \
+      && curl -fL https://download.konghq.com/gateway-${KONG_VERSION%%.*}.x-ubuntu-${UBUNTU_CODENAME}/pool/all/k/kong/kong_${KONG_VERSION}_$arch.deb -o /tmp/kong.deb \
       && apt-get purge -y curl \
       && echo "$KONG_SHA256  /tmp/kong.deb" | sha256sum -c -; \
     else \

--- a/update.sh
+++ b/update.sh
@@ -91,14 +91,21 @@ new_sha=$(sha256sum /tmp/kong | cut -b1-64)
 sed -i.bak 's/ARG KONG_SHA256=.*/ARG KONG_SHA256=\"'$new_sha'\"/g' Dockerfile.rpm
 sed -i.bak 's/ARG KONG_VERSION=.*/ARG KONG_VERSION='$version'/g' Dockerfile.rpm
 
-
 pushd ubuntu
    url=$(get_url Dockerfile amd64 "UBUNTU_CODENAME=focal")
    echo $url
    curl -fL $url -o /tmp/kong
    new_sha=$(sha256sum /tmp/kong | cut -b1-64)
 
-   sed -i.bak 's/ARG KONG_SHA256=.*/ARG KONG_SHA256=\"'$new_sha'\"/g' Dockerfile
+   sed -i.bak 's/ARG KONG_AMD64_SHA=.*/ARG KONG_AMD64_SHA=\"'$new_sha'\"/g' Dockerfile
+
+   url=$(get_url Dockerfile arm64 "UBUNTU_CODENAME=focal")
+   echo $url
+   curl -fL $url -o /tmp/kong
+   new_sha=$(sha256sum /tmp/kong | cut -b1-64)
+
+   sed -i.bak 's/ARG KONG_ARM64_SHA=.*/ARG KONG_ARM64_SHA=\"'$new_sha'\"/g' Dockerfile
+
    sed -i.bak 's/ARG KONG_VERSION=.*/ARG KONG_VERSION='$version'/g' Dockerfile
 popd
 


### PR DESCRIPTION
- Ensure architecture is parameterized, so both arm64 and amd64 images are built
- Ensure same kbt version as defined in kong/kong for a particular version is used here (they must match, mostly for testing purposes)
- Ensure shasum is checked for both arm64 and amd64 in the Ubuntu dockerfile
- Update automation (`update.sh`) to account for arm64 on Ubuntu