### PR TITLE
chore(non-rhel): unify maintainer to docker@

### DIFF
--- a/Dockerfile.apk
+++ b/Dockerfile.apk
@@ -1,5 +1,7 @@
 FROM alpine:3.16.0
 
+LABEL maintainer="Kong Docker Maintainers <docker@konghq.com> (@team-gateway-bot)"
+
 ARG KONG_VERSION=2.8.1
 ENV KONG_VERSION $KONG_VERSION
 

--- a/Dockerfile.deb
+++ b/Dockerfile.deb
@@ -1,5 +1,7 @@
 FROM debian:bullseye-20220509-slim
 
+LABEL maintainer="Kong Docker Maintainers <docker@konghq.com> (@team-gateway-bot)"
+
 ARG KONG_VERSION=2.8.1
 ENV KONG_VERSION $KONG_VERSION
 

--- a/Dockerfile.rpm
+++ b/Dockerfile.rpm
@@ -1,5 +1,7 @@
 FROM redhat/ubi8
 
+LABEL maintainer="Kong Docker Maintainers <docker@konghq.com> (@team-gateway-bot)"
+
 ARG KONG_VERSION=2.8.1
 ENV KONG_VERSION $KONG_VERSION
 

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.16
 
-LABEL maintainer="Kong <support@konghq.com>"
+LABEL maintainer="Kong Docker Maintainers <docker@konghq.com> (@team-gateway-bot)"
 
 ARG ASSET=ce
 ENV ASSET $ASSET

--- a/centos/Dockerfile
+++ b/centos/Dockerfile
@@ -1,5 +1,6 @@
 FROM centos:8
-LABEL maintainer="Kong <support@konghq.com>"
+
+LABEL maintainer="Kong Docker Maintainers <docker@konghq.com> (@team-gateway-bot)"
 
 ARG ASSET=ce
 ENV ASSET $ASSET

--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:focal
 
+LABEL maintainer="Kong Docker Maintainers <docker@konghq.com> (@team-gateway-bot)"
+
 ARG ASSET=ce
 ENV ASSET $ASSET
 


### PR DESCRIPTION
This uses the new `docker@` alias so that we can more faithfully follow up on feedback re: our containers.
This PR only targets dockerfiles NOT covered by a similar commit on https://github.com/Kong/docker-kong/pull/576 (https://github.com/Kong/docker-kong/pull/576/commits/7e60a40a6995ad71cf6b8996a938cc5aa5b978f3)