### PR TITLE
fix(dependency): remove openssl since we build ourselves

### DIFF
--- a/Dockerfile.apk
+++ b/Dockerfile.apk
@@ -26,7 +26,7 @@ RUN set -ex; \
       && echo "$KONG_SHA256  /tmp/kong.apk.tar.gz" | sha256sum -c -; \
     fi \
     && tar -C / -xzf /tmp/kong.apk.tar.gz \
-    && apk add --no-cache libstdc++ libgcc openssl pcre perl tzdata libcap zlib zlib-dev bash \
+    && apk add --no-cache libstdc++ libgcc pcre perl tzdata libcap zlib zlib-dev bash \
     && adduser -S kong \
     && addgroup -S kong \
     && mkdir -p "/usr/local/kong" \


### PR DESCRIPTION
We've built openssl ourselves since around ~2.x so I can't see why this is still required