### PR TITLE
perf(Dockerfile): reduce the HEALTHCHECK frequency

### DIFF
--- a/Dockerfile.apk
+++ b/Dockerfile.apk
@@ -51,6 +51,6 @@ EXPOSE 8000 8443 8001 8444 $EE_PORTS
 
 STOPSIGNAL SIGQUIT
 
-HEALTHCHECK --interval=10s --timeout=10s --retries=10 CMD kong health
+HEALTHCHECK --interval=60s --timeout=10s --retries=10 CMD kong health
 
 CMD ["kong", "docker-start"]

--- a/Dockerfile.apk
+++ b/Dockerfile.apk
@@ -9,6 +9,9 @@ ENV KONG_VERSION $KONG_VERSION
 ARG KONG_AMD64_SHA="b8e21beb32f803fae0959694ce7b6cec796a4159757e61b9cc0d30bed9682d10"
 ARG KONG_ARM64_SHA="4c5407c5ef2f0f29468e15ea4dc6a3f27011dbde3ce18170e4a4fd7e2bb2c03b"
 
+ARG KONG_PREFIX=/usr/local/kong
+ENV KONG_PREFIX $KONG_PREFIX
+
 ARG ASSET=remote
 ARG EE_PORTS
 
@@ -29,10 +32,10 @@ RUN set -ex; \
     && apk add --no-cache libstdc++ libgcc pcre perl tzdata libcap zlib zlib-dev bash \
     && adduser -S kong \
     && addgroup -S kong \
-    && mkdir -p "/usr/local/kong" \
-    && chown -R kong:0 /usr/local/kong \
+    && mkdir -p "${KONG_PREFIX}" \
+    && chown -R kong:0 ${KONG_PREFIX} \
     && chown kong:0 /usr/local/bin/kong \
-    && chmod -R g=u /usr/local/kong \
+    && chmod -R g=u ${KONG_PREFIX} \
     && rm -rf /tmp/kong.tar.gz \
     && ln -s /usr/local/openresty/bin/resty /usr/local/bin/resty \
     && ln -s /usr/local/openresty/luajit/bin/luajit /usr/local/bin/luajit \

--- a/Dockerfile.deb
+++ b/Dockerfile.deb
@@ -45,6 +45,6 @@ EXPOSE 8000 8443 8001 8444 $EE_PORTS
 
 STOPSIGNAL SIGQUIT
 
-HEALTHCHECK --interval=10s --timeout=10s --retries=10 CMD kong health
+HEALTHCHECK --interval=60s --timeout=10s --retries=10 CMD kong health
 
 CMD ["kong", "docker-start"]

--- a/Dockerfile.deb
+++ b/Dockerfile.deb
@@ -8,6 +8,9 @@ ENV KONG_VERSION $KONG_VERSION
 
 ARG KONG_SHA256="fa193923f0345a84af52497dc7d8a3d5d01416694cda415e2d69d901306d3fca"
 
+ARG KONG_PREFIX=/usr/local/kong
+ENV KONG_PREFIX $KONG_PREFIX
+
 ARG ASSET=remote
 ARG EE_PORTS
 
@@ -27,7 +30,7 @@ RUN set -ex; \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /tmp/kong.deb \
     && chown kong:0 /usr/local/bin/kong \
-    && chown -R kong:0 /usr/local/kong \
+    && chown -R kong:0 ${KONG_PREFIX} \
     && ln -s /usr/local/openresty/bin/resty /usr/local/bin/resty \
     && ln -s /usr/local/openresty/luajit/bin/luajit /usr/local/bin/luajit \
     && ln -s /usr/local/openresty/luajit/bin/luajit /usr/local/bin/lua \

--- a/Dockerfile.rpm
+++ b/Dockerfile.rpm
@@ -20,6 +20,9 @@ COPY LICENSE /licenses/
 
 ARG KONG_SHA256="c8b529f8e9dbcb2923b847f61c1039965426b141c96cb11c754dcf45e3088bdc"
 
+ARG KONG_PREFIX=/usr/local/kong
+ENV KONG_PREFIX $KONG_PREFIX
+
 ARG ASSET=remote
 ARG EE_PORTS
 
@@ -48,7 +51,7 @@ RUN set -ex; \
     && microdnf -y clean all \
     && rm /tmp/kong.rpm \
     && chown kong:0 /usr/local/bin/kong \
-    && chown -R kong:0 /usr/local/kong \
+    && chown -R kong:0 ${KONG_PREFIX} \
     && ln -s /usr/local/openresty/bin/resty /usr/local/bin/resty \
     && ln -s /usr/local/openresty/luajit/bin/luajit /usr/local/bin/luajit \
     && ln -s /usr/local/openresty/luajit/bin/luajit /usr/local/bin/lua \

--- a/Dockerfile.rpm
+++ b/Dockerfile.rpm
@@ -65,6 +65,6 @@ EXPOSE 8000 8443 8001 8444 $EE_PORTS
 
 STOPSIGNAL SIGQUIT
 
-HEALTHCHECK --interval=10s --timeout=10s --retries=10 CMD kong health
+HEALTHCHECK --interval=60s --timeout=10s --retries=10 CMD kong health
 
 CMD ["kong", "docker-start"]

--- a/build_your_own_images.md
+++ b/build_your_own_images.md
@@ -2,7 +2,7 @@
 
 Kong Software uses the [docker-kong github
 repository](https://github.com/Kong/docker-kong/) to build Docker images that
-contain the Kong Gateway. We will use  
+contain the Kong Gateway. We will use
 [docker-kong](https://github.com/Kong/docker-kong/) as a reference
 implementation for describing how to build your own Docker images that contain the Kong
 Gateway.
@@ -10,13 +10,13 @@ Gateway.
 We do not provide a Dockerfile with the `FROM` argument parametrized to allow you to use your
 own base image because doing so impedes our ability to get public images
 accepted promptly by Dockerhub. If you wish, you can clone the [docker-kong github
-repository](https://github.com/Kong/docker-kong/) and adjust the Dockerfile for 
-your desired package type to use your desired base image and package version, 
+repository](https://github.com/Kong/docker-kong/) and adjust the Dockerfile for
+your desired package type to use your desired base image and package version,
 then use the `build_v2` target in our `Makefile` to build your image. This
 document instead takes the approach of walking through the contents of the Dockerfiles
-so that you can create and maintain your own.  
+so that you can create and maintain your own.
 
-To build your Docker image, you will need to provide 
+To build your Docker image, you will need to provide
 
 1. A base image of your choice
 1. An entrypoint script that runs the Kong Gateway
@@ -46,7 +46,7 @@ Dockerfile to
 
 If you choose 1 or 2, run the command `touch kong.rpm` in the directory to which
 your Dockerfile will download the file; this guarantees that the downloaded file
-will have the correct user, groups, and permissions. 
+will have the correct user, groups, and permissions.
 
 If you choose 2 or 3, then download the package you wish to install and put it
 in the desired location.
@@ -58,28 +58,28 @@ you need to uncomment lines relevant to your context.
 
 The template is based upon the Dockerfiles in the [docker-kong github
 repository](https://github.com/Kong/docker-kong/) and created manually. Check
-the Dockerfiles for changes. 
+the Dockerfiles for changes.
 
 ```
-FROM <your-base-image> 
+FROM <your-base-image>
 
 ARG KONG_VERSION=<Kong-Gateway-version>=
 ENV KONG_VERSION $KONG_VERSION
 
-# Uncomment the ARG KONG_SHA256 line to build a container using a .deb or .rpm package 
+# Uncomment the ARG KONG_SHA256 line to build a container using a .deb or .rpm package
 # For .deb packages, the SHA is in
-# https://download.konghq.com/gateway-<gateway-major-version>-<os>-<os_version>/dists/default/all/binary-amd64/Packages 
-# For .rpm packages, the SHA is in 
-# https://download.konghq.com/gateway-<gateway-major-version>-<os>-<os_version>/repodata/<some-sha>-primary.xml.gz 
+# https://download.konghq.com/gateway-<gateway-major-version>-<os>-<os_version>/dists/default/all/binary-amd64/Packages
+# For .rpm packages, the SHA is in
+# https://download.konghq.com/gateway-<gateway-major-version>-<os>-<os_version>/repodata/<some-sha>-primary.xml.gz
 # ARG KONG_SHA256="<.deb-or.rpm-SHA>"
 
-# Uncomment to build a container using the .apk.tar.gz Kong Gateway package 
+# Uncomment to build a container using the .apk.tar.gz Kong Gateway package
 # For .apk.tar.gz packages, the SHA is in
-# https://download.konghq.com/gateway-<gateway-major-version>-alpine/PULP_MANIFEST 
+# https://download.konghq.com/gateway-<gateway-major-version>-alpine/PULP_MANIFEST
 # ARG KONG_AMD64_SHA="<amd64_sha>"
 # ARG KONG_ARM64_SHA="<arm64_sha>"
 
-# Uncomment to download package from a remote repository 
+# Uncomment to download package from a remote repository
 # ARG ASSET=remote
 
 # Uncomment to install package from local disk
@@ -87,7 +87,7 @@ ENV KONG_VERSION $KONG_VERSION
 
 ARG EE_PORTS
 
-# Uncomment if you are installing a .rpm 
+# Uncomment if you are installing a .rpm
 # COPY kong.rpm /tmp/kong.rpm
 
 # Uncomment if you are installing a .deb
@@ -118,7 +118,7 @@ ARG EE_PORTS
 #     && kong version
 
 # Uncomment the following section if you are installing a .deb
-# Edit the DOWNLOAD_URL line to install from a repository other than 
+# Edit the DOWNLOAD_URL line to install from a repository other than
 # download.konghq.com
 # RUN set -ex; \
 #     apt-get update; \
@@ -143,7 +143,7 @@ ARG EE_PORTS
 #    && apt-get purge curl -y
 
 # Uncomment the following section if you are installing a .apk.tar.gz
-# Edit the DOWNLOAD_URL line to install from a repository other than 
+# Edit the DOWNLOAD_URL line to install from a repository other than
 # download.konghq.com
 # RUN set -ex; \
 #     apk add bash curl ca-certificates; \
@@ -183,7 +183,7 @@ EXPOSE 8000 8443 8001 8444 $EE_PORTS
 
 STOPSIGNAL SIGQUIT
 
-HEALTHCHECK --interval=10s --timeout=10s --retries=10 CMD kong health
+HEALTHCHECK --interval=60s --timeout=10s --retries=10 CMD kong health
 
 CMD ["kong", "docker-start"]
 ```

--- a/customize/Dockerfile
+++ b/customize/Dockerfile
@@ -51,6 +51,6 @@ RUN true
 #COPY --from=build /usr/local/bin /usr/local/bin
 
 
-HEALTHCHECK --interval=10s --timeout=10s --retries=10 CMD kong health
+HEALTHCHECK --interval=60s --timeout=10s --retries=10 CMD kong health
 
 USER kong


### PR DESCRIPTION
The `kong health` can get expensive to execute too frequently, this PR reduces the frequency it is called by default. It also sets `KONG_PREFIX` `ARG` and `ENV` variables, so the `kong health` command does not need to load the config file to find the Nginx prefix.

FTI-4452