### PR TITLE
fix(docker-entrypoint): clean-up dangling unix sockets

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -45,9 +45,18 @@ if [[ "$1" == "kong" ]]; then
     kong prepare -p "$PREFIX" "$@"
 
     # remove all dangling sockets in $PREFIX dir before starting Kong
+    LOGGED_SOCKET_WARNING=0
     for localfile in "$PREFIX"/*; do
-      if [ -S $localfile ]; then
-        rm -f $localfile
+      if [ -S "$localfile" ]; then
+        if (( LOGGED_SOCKET_WARNING == 0 )); then
+          printf >&2 'WARN: found dangling unix sockets in the prefix directory '
+          printf >&2 '(%q) ' "$PREFIX"
+          printf >&2 'while preparing to start Kong. This may be a sign that Kong '
+          printf >&2 'was previously shut down uncleanly or is in an unknown state '
+          printf >&2 'and could require further investigation.\n'
+          LOGGED_SOCKET_WARNING=1
+        fi
+        rm -f "$localfile"
       fi
     done
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -44,6 +44,13 @@ if [[ "$1" == "kong" ]]; then
   if [[ "$2" == "docker-start" ]]; then
     kong prepare -p "$PREFIX" "$@"
 
+    # remove all dangling sockets in $PREFIX dir before starting Kong
+    for localfile in "$PREFIX"/*; do
+      if [ -S $localfile ]; then
+        rm -f $localfile
+      fi
+    done
+
     ln -sf /dev/stdout $PREFIX/logs/access.log
     ln -sf /dev/stdout $PREFIX/logs/admin_access.log
     ln -sf /dev/stderr $PREFIX/logs/error.log

--- a/ubuntu/docker-entrypoint.sh
+++ b/ubuntu/docker-entrypoint.sh
@@ -44,6 +44,22 @@ if [[ "$1" == "kong" ]]; then
   if [[ "$2" == "docker-start" ]]; then
     kong prepare -p "$PREFIX" "$@"
 
+    # remove all dangling sockets in $PREFIX dir before starting Kong
+    LOGGED_SOCKET_WARNING=0
+    for localfile in "$PREFIX"/*; do
+      if [ -S "$localfile" ]; then
+        if (( LOGGED_SOCKET_WARNING == 0 )); then
+          printf >&2 'WARN: found dangling unix sockets in the prefix directory '
+          printf >&2 '(%q) ' "$PREFIX"
+          printf >&2 'while preparing to start Kong. This may be a sign that Kong '
+          printf >&2 'was previously shut down uncleanly or is in an unknown state '
+          printf >&2 'and could require further investigation.\n'
+          LOGGED_SOCKET_WARNING=1
+        fi
+        rm -f "$localfile"
+      fi
+    done
+
     ln -sf /dev/stdout $PREFIX/logs/access.log
     ln -sf /dev/stdout $PREFIX/logs/admin_access.log
     ln -sf /dev/stderr $PREFIX/logs/error.log


### PR DESCRIPTION
This change adds a clean-up step to remove all sockets that a previous Kong run may have left in $PREFIX directory.

Dangling unix sockets have been a pain point in recent Kong versions and was dealt in traditional Kong in Kong/kong#9254, but the `kong` script is not called when starting Kong inside a container, so a similar change to `docker-entrypoint.sh` was added here. 

FTI-4525