### PR TITLE
feat(Dockerfile) use kong-health to check container health

### DIFF
--- a/Dockerfile.apk
+++ b/Dockerfile.apk
@@ -54,6 +54,6 @@ EXPOSE 8000 8443 8001 8444 $EE_PORTS
 
 STOPSIGNAL SIGQUIT
 
-HEALTHCHECK --interval=60s --timeout=10s --retries=10 CMD kong health
+HEALTHCHECK --interval=60s --timeout=10s --retries=10 CMD kong-health
 
 CMD ["kong", "docker-start"]

--- a/Dockerfile.deb
+++ b/Dockerfile.deb
@@ -48,6 +48,6 @@ EXPOSE 8000 8443 8001 8444 $EE_PORTS
 
 STOPSIGNAL SIGQUIT
 
-HEALTHCHECK --interval=60s --timeout=10s --retries=10 CMD kong health
+HEALTHCHECK --interval=60s --timeout=10s --retries=10 CMD kong-health
 
 CMD ["kong", "docker-start"]

--- a/Dockerfile.rpm
+++ b/Dockerfile.rpm
@@ -68,6 +68,6 @@ EXPOSE 8000 8443 8001 8444 $EE_PORTS
 
 STOPSIGNAL SIGQUIT
 
-HEALTHCHECK --interval=60s --timeout=10s --retries=10 CMD kong health
+HEALTHCHECK --interval=60s --timeout=10s --retries=10 CMD kong-health
 
 CMD ["kong", "docker-start"]

--- a/build_your_own_images.md
+++ b/build_your_own_images.md
@@ -183,7 +183,7 @@ EXPOSE 8000 8443 8001 8444 $EE_PORTS
 
 STOPSIGNAL SIGQUIT
 
-HEALTHCHECK --interval=60s --timeout=10s --retries=10 CMD kong health
+HEALTHCHECK --interval=60s --timeout=10s --retries=10 CMD kong-health
 
 CMD ["kong", "docker-start"]
 ```

--- a/customize/Dockerfile
+++ b/customize/Dockerfile
@@ -51,6 +51,6 @@ RUN true
 #COPY --from=build /usr/local/bin /usr/local/bin
 
 
-HEALTHCHECK --interval=60s --timeout=10s --retries=10 CMD kong health
+HEALTHCHECK --interval=60s --timeout=10s --retries=10 CMD kong-health
 
 USER kong


### PR DESCRIPTION
Use the `kong-health` standalone script to check container health, avoiding config parsing overhead on `kong health`.

KAG-263
FTI-4452 