### PR TITLE
feat(Dockerfile): reduce container health-check overhead

### DIFF
--- a/Dockerfile.apk
+++ b/Dockerfile.apk
@@ -52,6 +52,6 @@ EXPOSE 8000 8443 8001 8444 $EE_PORTS
 
 STOPSIGNAL SIGQUIT
 
-HEALTHCHECK --interval=60s --timeout=10s --retries=10 CMD kong health
+HEALTHCHECK --interval=60s --timeout=10s --retries=10 CMD kong-health
 
 CMD ["kong", "docker-start"]

--- a/Dockerfile.apk
+++ b/Dockerfile.apk
@@ -6,6 +6,9 @@ ENV KONG_VERSION $KONG_VERSION
 ARG KONG_AMD64_SHA="962ac92c9834cb59f1d6563412714f3d6eecfe6c6849a84cfcbe7a4b3facbf46"
 ARG KONG_ARM64_SHA="7076e6ee6a03df86795a1a08cf86e0349a150095e61be266db462cb7de9fd745"
 
+ARG KONG_PREFIX=/usr/local/kong
+ENV KONG_PREFIX $KONG_PREFIX
+
 ARG ASSET=remote
 ARG EE_PORTS
 
@@ -27,10 +30,10 @@ RUN set -ex; \
     && apk add --no-cache libstdc++ libgcc openssl pcre perl tzdata libcap zlib zlib-dev bash \
     && adduser -S kong \
     && addgroup -S kong \
-    && mkdir -p "/usr/local/kong" \
-    && chown -R kong:0 /usr/local/kong \
+    && mkdir -p "${KONG_PREFIX}" \
+    && chown -R kong:0 ${KONG_PREFIX} \
     && chown kong:0 /usr/local/bin/kong \
-    && chmod -R g=u /usr/local/kong \
+    && chmod -R g=u ${KONG_PREFIX} \
     && rm -rf /tmp/kong.tar.gz \
     && ln -s /usr/local/openresty/bin/resty /usr/local/bin/resty \
     && ln -s /usr/local/openresty/luajit/bin/luajit /usr/local/bin/luajit \
@@ -49,6 +52,6 @@ EXPOSE 8000 8443 8001 8444 $EE_PORTS
 
 STOPSIGNAL SIGQUIT
 
-HEALTHCHECK --interval=10s --timeout=10s --retries=10 CMD kong health
+HEALTHCHECK --interval=60s --timeout=10s --retries=10 CMD kong health
 
 CMD ["kong", "docker-start"]

--- a/Dockerfile.deb
+++ b/Dockerfile.deb
@@ -5,6 +5,9 @@ ENV KONG_VERSION $KONG_VERSION
 
 ARG KONG_SHA256="5f1298c36791456f6ef67420a4aca391c90ba9051f38caa0d9cfac3c6424d839"
 
+ARG KONG_PREFIX=/usr/local/kong
+ENV KONG_PREFIX $KONG_PREFIX
+
 ARG ASSET=remote
 ARG EE_PORTS
 
@@ -24,7 +27,7 @@ RUN set -ex; \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /tmp/kong.deb \
     && chown kong:0 /usr/local/bin/kong \
-    && chown -R kong:0 /usr/local/kong \
+    && chown -R kong:0 ${KONG_PREFIX} \
     && ln -s /usr/local/openresty/bin/resty /usr/local/bin/resty \
     && ln -s /usr/local/openresty/luajit/bin/luajit /usr/local/bin/luajit \
     && ln -s /usr/local/openresty/luajit/bin/luajit /usr/local/bin/lua \
@@ -42,6 +45,6 @@ EXPOSE 8000 8443 8001 8444 $EE_PORTS
 
 STOPSIGNAL SIGQUIT
 
-HEALTHCHECK --interval=10s --timeout=10s --retries=10 CMD kong health
+HEALTHCHECK --interval=60s --timeout=10s --retries=10 CMD kong health
 
 CMD ["kong", "docker-start"]

--- a/Dockerfile.deb
+++ b/Dockerfile.deb
@@ -45,6 +45,6 @@ EXPOSE 8000 8443 8001 8444 $EE_PORTS
 
 STOPSIGNAL SIGQUIT
 
-HEALTHCHECK --interval=60s --timeout=10s --retries=10 CMD kong health
+HEALTHCHECK --interval=60s --timeout=10s --retries=10 CMD kong-health
 
 CMD ["kong", "docker-start"]

--- a/Dockerfile.rpm
+++ b/Dockerfile.rpm
@@ -5,6 +5,9 @@ ENV KONG_VERSION $KONG_VERSION
 
 ARG KONG_SHA256="1f67d6c35a359608505b7a65f4bd9f5b459d28a8bc2ca1c70f101fe78c331139"
 
+ARG KONG_PREFIX=/usr/local/kong
+ENV KONG_PREFIX $KONG_PREFIX
+
 ARG ASSET=remote
 ARG EE_PORTS
 
@@ -21,7 +24,7 @@ RUN set -ex; \
     && yum install -y /tmp/kong.rpm \
     && rm /tmp/kong.rpm \
     && chown kong:0 /usr/local/bin/kong \
-    && chown -R kong:0 /usr/local/kong \
+    && chown -R kong:0 ${KONG_PREFIX} \
     && ln -s /usr/local/openresty/bin/resty /usr/local/bin/resty \
     && ln -s /usr/local/openresty/luajit/bin/luajit /usr/local/bin/luajit \
     && ln -s /usr/local/openresty/luajit/bin/luajit /usr/local/bin/lua \
@@ -38,6 +41,6 @@ EXPOSE 8000 8443 8001 8444 $EE_PORTS
 
 STOPSIGNAL SIGQUIT
 
-HEALTHCHECK --interval=10s --timeout=10s --retries=10 CMD kong health
+HEALTHCHECK --interval=60s --timeout=10s --retries=10 CMD kong health
 
 CMD ["kong", "docker-start"]

--- a/Dockerfile.rpm
+++ b/Dockerfile.rpm
@@ -41,6 +41,6 @@ EXPOSE 8000 8443 8001 8444 $EE_PORTS
 
 STOPSIGNAL SIGQUIT
 
-HEALTHCHECK --interval=60s --timeout=10s --retries=10 CMD kong health
+HEALTHCHECK --interval=60s --timeout=10s --retries=10 CMD kong-health
 
 CMD ["kong", "docker-start"]

--- a/customize/Dockerfile
+++ b/customize/Dockerfile
@@ -51,6 +51,6 @@ RUN true
 #COPY --from=build /usr/local/bin /usr/local/bin
 
 
-HEALTHCHECK --interval=60s --timeout=10s --retries=10 CMD kong health
+HEALTHCHECK --interval=60s --timeout=10s --retries=10 CMD kong-health
 
 USER kong

--- a/customize/Dockerfile
+++ b/customize/Dockerfile
@@ -51,6 +51,6 @@ RUN true
 #COPY --from=build /usr/local/bin /usr/local/bin
 
 
-HEALTHCHECK --interval=10s --timeout=10s --retries=10 CMD kong health
+HEALTHCHECK --interval=60s --timeout=10s --retries=10 CMD kong health
 
 USER kong


### PR DESCRIPTION
This change contains cherry-picks from #599 and #621, increasing the period the health-check script is called and using the new `kong-health` script.


FTI-4452
KAG-263