### PR TITLE
fix(docker-compose): adding database name to pg_isready

### DIFF
--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -105,7 +105,15 @@ services:
     secrets:
       - kong_postgres_password
     healthcheck:
-      test: ["CMD", "pg_isready", "-U", "${KONG_PG_USER:-kong}"]
+      test:
+        [
+          "CMD",
+          "pg_isready",
+          "-d",
+          "${KONG_PG_DATABASE:-kong}",
+          "-U",
+          "${KONG_PG_USER:-kong}"
+        ]
       interval: 30s
       timeout: 30s
       retries: 3

--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -1,6 +1,7 @@
 version: '3.9'
 
-x-kong-config: &kong-env
+x-kong-config:
+  &kong-env
   KONG_DATABASE: ${KONG_DATABASE:-off}
   KONG_PG_DATABASE: ${KONG_PG_DATABASE:-kong}
   KONG_PG_HOST: db
@@ -11,12 +12,12 @@ volumes:
   kong_data: {}
   kong_prefix_vol:
     driver_opts:
-     type: tmpfs
-     device: tmpfs
+      type: tmpfs
+      device: tmpfs
   kong_tmp_vol:
     driver_opts:
-     type: tmpfs
-     device: tmpfs
+      type: tmpfs
+      device: tmpfs
 
 networks:
   kong-net:
@@ -26,7 +27,7 @@ services:
   kong-migrations:
     image: "${KONG_DOCKER_TAG:-kong:latest}"
     command: kong migrations bootstrap
-    profiles: ["database"]
+    profiles: [ "database" ]
     depends_on:
       - db
     environment:
@@ -40,7 +41,7 @@ services:
   kong-migrations-up:
     image: "${KONG_DOCKER_TAG:-kong:latest}"
     command: kong migrations up && kong migrations finish
-    profiles: ["database"]
+    profiles: [ "database" ]
     depends_on:
       - db
     environment:
@@ -81,7 +82,7 @@ services:
       - "127.0.0.1:8001:8001/tcp"
       - "127.0.0.1:8444:8444/tcp"
     healthcheck:
-      test: ["CMD", "kong", "health"]
+      test: [ "CMD", "kong", "health" ]
       interval: 10s
       timeout: 10s
       retries: 10
@@ -96,7 +97,7 @@ services:
 
   db:
     image: postgres:9.5
-    profiles: ["database"]
+    profiles: [ "database" ]
     environment:
       POSTGRES_DB: ${KONG_PG_DATABASE:-kong}
       POSTGRES_USER: ${KONG_PG_USER:-kong}


### PR DESCRIPTION
When not using `KONG_PG_DATABASE` default (which is _kong_), the _pg_isready_ command is not working as expected.

Therefore this PR is only to add `-d ${KONG_PG_DATABASE:-kong}` to the healthcheck command.