### PR TITLE
Fix 3.2 changes

### DIFF
--- a/customize/Dockerfile
+++ b/customize/Dockerfile
@@ -20,6 +20,7 @@ COPY packer.lua /packer.lua
 
 USER root
 
+RUN cp /usr/local/lib/luarocks/rocks-5.1/luarocks/3.9.2-1/bin/luarocks-admin /usr/local/bin/
 RUN /usr/local/openresty/luajit/bin/luajit /packer.lua -- "$INJECTED_PLUGINS"
 
 FROM ${KONG_BASE}

--- a/customize/packer.lua
+++ b/customize/packer.lua
@@ -338,7 +338,6 @@ then
 else
     assert(exec("mv /entrypoint.sh /old-entrypoint.sh")) -- for new version
 end
-assert(exec("ls /old-entrypoint.sh"))
 local entrypoint = [=[
 #!/bin/sh
 set -e

--- a/customize/packer.lua
+++ b/customize/packer.lua
@@ -328,7 +328,9 @@ end
 
 
 header("Write new entry-point script")
-assert(exec("mv /docker-entrypoint.sh /old-entrypoint.sh"))
+exec("mv /docker-entrypoint.sh /old-entrypoint.sh"). -- for old version
+exec("mv /entrypoint.sh /old-entrypoint.sh") -- for new version
+assert(exec("ls /old-entrypoint.sh"))
 local entrypoint = [=[
 #!/bin/sh
 set -e

--- a/customize/packer.lua
+++ b/customize/packer.lua
@@ -116,6 +116,10 @@ local function prep_platform()
   stderr("WARNING: no platform match!")
 end
 
+local function file_exists(name)
+   local f = io.open(name, "r")
+   return f ~= nil and io.close(f)
+end
 
 local function is_empty_file(filename)
   local t = readfile(filename)
@@ -328,8 +332,12 @@ end
 
 
 header("Write new entry-point script")
-exec("mv /docker-entrypoint.sh /old-entrypoint.sh"). -- for old version
-exec("mv /entrypoint.sh /old-entrypoint.sh") -- for new version
+if file_exists("/docker-entrypoint.sh")
+then
+    assert(exec("mv /docker-entrypoint.sh /old-entrypoint.sh")) -- for old version
+else
+    assert(exec("mv /entrypoint.sh /old-entrypoint.sh")) -- for new version
+end
 assert(exec("ls /old-entrypoint.sh"))
 local entrypoint = [=[
 #!/bin/sh


### PR DESCRIPTION
Fix for 3.2 changes:
- file seems to be called entrypoint.sh no more docker-entrypoint
- missing symlinks https://kongstrong.slack.com/archives/C0496KBU16E/p1676401319527349
https://konghq.atlassian.net/browse/KAG-617