### PR TITLE
feat: enable and bind to localhost for Admin UI

### DIFF
--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -60,6 +60,7 @@ services:
       KONG_ADMIN_ERROR_LOG: /dev/stderr
       KONG_PROXY_LISTEN: "${KONG_PROXY_LISTEN:-0.0.0.0:8000}"
       KONG_ADMIN_LISTEN: "${KONG_ADMIN_LISTEN:-0.0.0.0:8001}"
+      KONG_ADMIN_GUI_LISTEN: "${KONG_ADMIN_GUI_LISTEN:-0.0.0.0:8002}"
       KONG_PROXY_ACCESS_LOG: /dev/stdout
       KONG_PROXY_ERROR_LOG: /dev/stderr
       KONG_PREFIX: ${KONG_PREFIX:-/var/run/kong}
@@ -80,6 +81,7 @@ services:
 
       - "127.0.0.1:8001:8001/tcp"
       - "127.0.0.1:8444:8444/tcp"
+      - "127.0.0.1:8002:8002/tcp"
     healthcheck:
       test: ["CMD", "kong", "health"]
       interval: 10s


### PR DESCRIPTION
This patch enables Kong Manager by default and binds it to the same interfaces as Kong's Admin API by default.