### PR TITLE
Remove libcurl dependency

### DIFF
--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -27,7 +27,7 @@ RUN set -ex; \
       apt-get install -y --no-install-recommends curl ca-certificates \
       && UBUNTU_CODENAME=$(cat /etc/os-release | grep UBUNTU_CODENAME | cut -d = -f 2) \
       && curl -fL https://download.konghq.com/gateway-${KONG_VERSION%%.*}.x-ubuntu-${UBUNTU_CODENAME}/pool/all/k/kong/kong_${KONG_VERSION}_$arch.deb -o /tmp/kong.deb \
-      && apt-get purge -y curl \
+      && apt-get purge --autoremove -y curl \
       && echo "$KONG_SHA256  /tmp/kong.deb" | sha256sum -c - \
       || exit 1; \
     else \


### PR DESCRIPTION
### Summary

When building the Kong docker image for Ubuntu, some cURL/libcurl related CVE findings occur in the image when perfoming a container security scan.

cURL is purged after usage inside the [Dockerfile](https://github.com/Kong/docker-kong/blob/3.4.1/ubuntu/Dockerfile#L30), but the libcurl dependency is left. Container security scanners find CVEs related to cURL (like CVE-2023-38545). By adding `--autoremove` option to the purge command, the libcurl dependency will also get purged.

<sup>Manuel Gugel <manuel_sebastian.gugel@[mercedes-benz.com](http://daimler.com/)>, Mercedes-Benz Tech Innovation GmbH, [imprint](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)</sup>