### PR TITLE
chore(conf): Docker Compose V2 compliant

### DIFF
--- a/compose/Makefile
+++ b/compose/Makefile
@@ -1,9 +1,9 @@
 kong-postgres:
-	COMPOSE_PROFILES=database KONG_DATABASE=postgres docker-compose up -d
+	COMPOSE_PROFILES=database KONG_DATABASE=postgres docker compose up -d
 
 kong-dbless:
-	docker-compose up -d
+	docker compose up -d
 
 clean:
-	docker-compose kill
-	docker-compose rm -f
+	docker compose kill
+	docker compose rm -f

--- a/compose/compose.yml
+++ b/compose/compose.yml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 x-kong-config:
   &kong-env
   KONG_DATABASE: ${KONG_DATABASE:-off}


### PR DESCRIPTION
Modified files to the format standardized in Docker Compose V2

> Tip
>
>Update scripts to use Compose V2 by replacing the hyphen (-) with a space, using docker compose instead of docker-compose.
> https://docs.docker.com/compose/migrate/#what-are-the-differences-between-compose-v1-and-compose-v2

> The default path for a Compose file is compose.yaml (preferred) or compose.yml that is placed in the working directory. Compose also supports docker-compose.yaml and docker-compose.yml for backwards compatibility of earlier versions. If both files exist, Compose prefers the canonical compose.yaml.
> https://docs.docker.com/compose/compose-file/03-compose-file/

>The top-level version property is defined by the Compose Specification for backward compatibility. It is only informative.
> https://docs.docker.com/compose/compose-file/04-version-and-name/#version-and-name-top-level-elements
