### PR TITLE
feat(*): use cloudsmith instead of pulp to download packages

### DIFF
--- a/Dockerfile.deb
+++ b/Dockerfile.deb
@@ -2,10 +2,10 @@
 FROM debian:bullseye-20230502-slim
 
 LABEL maintainer="Kong Docker Maintainers <docker@konghq.com> (@team-gateway-bot)"
-ARG KONG_VERSION=3.6.1
+ARG KONG_VERSION=3.7.0
 ENV KONG_VERSION $KONG_VERSION
 
-ARG KONG_SHA256="97da5168777d5ebc48ff5488d254bee930c52a631203e94c76b3b9dcc83a5d5c"
+ARG KONG_SHA256="3f325e456d884f809b9480100dfb2ae613467fec6864a86e08c44b52a010d73a"
 
 ARG KONG_PREFIX=/usr/local/kong
 ENV KONG_PREFIX $KONG_PREFIX
@@ -20,7 +20,8 @@ RUN set -ex; \
     apt-get install -y curl; \
     if [ "$ASSET" = "remote" ] ; then \
       CODENAME=$(cat /etc/os-release | grep VERSION_CODENAME | cut -d = -f 2) \
-      && DOWNLOAD_URL="https://download.konghq.com/gateway-${KONG_VERSION%%.*}.x-debian-${CODENAME}/pool/all/k/kong/kong_${KONG_VERSION}_amd64.deb" \
+      && KONG_REPO=$(echo ${KONG_VERSION%.*} | sed 's/\.//') \
+      && DOWNLOAD_URL="https://packages.konghq.com/public/gateway-$KONG_REPO/deb/debian/pool/$CODENAME/main/k/ko/kong_$KONG_VERSION/kong_${KONG_VERSION}_amd64.deb" \
       && curl -fL $DOWNLOAD_URL -o /tmp/kong.deb \
       && echo "$KONG_SHA256  /tmp/kong.deb" | sha256sum -c -; \
     fi \

--- a/Dockerfile.rpm
+++ b/Dockerfile.rpm
@@ -3,7 +3,7 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7@sha256:6910799b75ad41f00891
 
 LABEL maintainer="Kong Docker Maintainers <docker@konghq.com> (@team-gateway-bot)"
 
-ARG KONG_VERSION=3.6.1
+ARG KONG_VERSION=3.7.0
 ENV KONG_VERSION $KONG_VERSION
 
 # RedHat required labels
@@ -18,7 +18,7 @@ LABEL name="Kong" \
 # RedHat required LICENSE file approved path
 COPY LICENSE /licenses/
 
-ARG KONG_SHA256="18b9cdcf7d89b4cbaa8d30c1115fea7e8f8ecfb8d4fd7126e3c3ff8c3d9b405c"
+ARG KONG_SHA256="f9f00e9674c970aa366cd2f4d6e597edb867084a84caee299c444cc973b5d8eb"
 
 ARG KONG_PREFIX=/usr/local/kong
 ENV KONG_PREFIX $KONG_PREFIX
@@ -31,7 +31,8 @@ COPY kong.rpm /tmp/kong.rpm
 # hadolint ignore=DL3015
 RUN set -ex; \
     if [ "$ASSET" = "remote" ] ; then \
-      DOWNLOAD_URL="https://download.konghq.com/gateway-${KONG_VERSION%%.*}.x-rhel-8/Packages/k/kong-$KONG_VERSION.rhel8.amd64.rpm" \
+      KONG_REPO=$(echo ${KONG_VERSION%.*} | sed 's/\.//') \
+      && DOWNLOAD_URL="https://packages.konghq.com/public/gateway-$KONG_REPO/rpm/el/8/x86_64/kong-$KONG_VERSION.el8.x86_64.rpm" \
       && curl -fL $DOWNLOAD_URL -o /tmp/kong.rpm \
       && echo "$KONG_SHA256  /tmp/kong.rpm" | sha256sum -c - \
       || exit 1; \

--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -9,11 +9,11 @@ ARG EE_PORTS
 
 COPY kong.deb /tmp/kong.deb
 
-ARG KONG_VERSION=3.6.1
+ARG KONG_VERSION=3.7.0
 ENV KONG_VERSION $KONG_VERSION
 
-ARG KONG_AMD64_SHA="03b2aca93fd41b8dc0908754cef815433c1d3069ac842a1d078ca98105b230fd"
-ARG KONG_ARM64_SHA="b544bfe2ba4109335d26efb5e59029450f823c3a19b6aef77f6c93d5850142b0"
+ARG KONG_AMD64_SHA="71b946cac188653eb29714f21b98eb146cec536e05a5818a49007f9211e572d4"
+ARG KONG_ARM64_SHA="fb01282dfe9bf42ba27df30c2bc269aadac3ae3f298ba535f77b15a7bff2f6df"
 
 # hadolint ignore=DL3015
 RUN set -ex; \
@@ -26,7 +26,8 @@ RUN set -ex; \
     && if [ "$ASSET" = "ce" ] ; then \
       apt-get install -y --no-install-recommends curl ca-certificates \
       && UBUNTU_CODENAME=$(cat /etc/os-release | grep UBUNTU_CODENAME | cut -d = -f 2) \
-      && curl -fL https://download.konghq.com/gateway-${KONG_VERSION%%.*}.x-ubuntu-${UBUNTU_CODENAME}/pool/all/k/kong/kong_${KONG_VERSION}_$arch.deb -o /tmp/kong.deb \
+      && KONG_REPO=$(echo ${KONG_VERSION%.*} | sed 's/\.//') \
+      && curl -fL https://packages.konghq.com/public/gateway-$KONG_REPO/deb/ubuntu/pool/$UBUNTU_CODENAME/main/k/ko/kong_$KONG_VERSION/kong_${KONG_VERSION}_$arch.deb \
       && apt-get purge -y curl \
       && echo "$KONG_SHA256  /tmp/kong.deb" | sha256sum -c - \
       || exit 1; \

--- a/update.sh
+++ b/update.sh
@@ -34,10 +34,11 @@ function get_url() {
 
   eval $args
 
-  raw_url=$(egrep -o 'https?://download.konghq.com/gateway-[^ ]+' $dockerfile | sed 's/\"//g')
+  raw_url=$(egrep -o 'https?://packages.konghq.com/public/gateway-[^ ]+' $dockerfile | sed 's/\"//g')
 
   # set variables contained in raw url
   KONG_VERSION=$version
+  KONG_REPO=$(echo ${KONG_VERSION%.*} | sed 's/\.//')
   ARCH=$arch
 
   eval echo $raw_url


### PR DESCRIPTION
This PR changes the source of `deb` and `rpm` packages from the old [pulp repository](https://download.konghq.com) to the new [cloudsmith repository](https://packages.konghq.com). 

The changes affect the `Dockerfile`s, the documentation and update script.

The Gateway version was also bumped to `3.7.0` in the process.

closes: #700 