### PR TITLE
Fix: Remove arm64 for 2.8

### DIFF
--- a/submit.sh
+++ b/submit.sh
@@ -174,7 +174,7 @@ then
         print "GitCommit: " commit
         print "GitFetch: refs/tags/" v
         print "Directory: ubuntu"
-        print "Architectures: amd64, arm64v8"
+        print "Architectures: amd64"
         print ""
         before_first = 0
       } else {
@@ -214,13 +214,13 @@ then
         print "GitCommit: " commit
         print "GitFetch: refs/tags/" v
         print "Directory: alpine"
-        print "Architectures: amd64, arm64v8"
+        print "Architectures: amd64"
         print ""
         print "Tags: " v "-ubuntu, " xy "-ubuntu, ubuntu"
         print "GitCommit: " commit
         print "GitFetch: refs/tags/" v
         print "Directory: ubuntu"
-        print "Architectures: amd64, arm64v8"
+        print "Architectures: amd64"
         print ""
         before_first = 0
       }


### PR DESCRIPTION
These changes should ensure that the next time 2.8 is released, it does not include an arm64 variant.

https://konghq.atlassian.net/browse/KAG-4469

Relates to: https://github.com/docker-library/official-images/pull/16962