### PR TITLE
fix(Dockerfile): install luarocks

### DIFF
--- a/Dockerfile.deb
+++ b/Dockerfile.deb
@@ -25,7 +25,13 @@ RUN set -ex; \
       && echo "${KONG_SHA256}  /tmp/kong.deb" | sha256sum -c -; \
     fi \
     && apt-get update \
-    && apt-get install --yes /tmp/kong.deb \
+    && apt-get install --yes /tmp/kong.deb lua5.1 liblua5.1-dev unzip make \
+    && curl -L https://luarocks.org/releases/luarocks-3.8.0.tar.gz -o luarocks-3.8.0.tar.gz \
+    && tar zxpf luarocks-3.8.0.tar.gz \
+    && cd luarocks-3.8.0 \
+    && ./configure && make && make install \
+    && export PATH=$PATH:/usr/local/bin/luarocks \
+    && cd - \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /tmp/kong.deb \
     && chown kong:0 /usr/local/bin/kong \

--- a/Dockerfile.rpm
+++ b/Dockerfile.rpm
@@ -22,7 +22,15 @@ RUN set -ex; \
       curl -fL $DOWNLOAD_URL -o /tmp/kong.rpm \
       && echo "${KONG_SHA256}  /tmp/kong.rpm" | sha256sum -c -; \
     fi \
-    && yum install -y /tmp/kong.rpm \
+    && yum install -y /tmp/kong.rpm wget gcc make ncurses-devel \
+    && wget https://ftp.gnu.org/gnu/readline/readline-8.2-rc4.tar.gz \
+    && tar zxvf readline-8.2-rc4.tar.gz && cd readline-8.2-rc4 && ./configure && make && make install && cd - \
+    && export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH \
+    && wget https://www.lua.org/ftp/lua-5.1.5.tar.gz && tar -zxvf lua-5.1.5.tar.gz \
+    && cd lua-5.1.5 && make linux && make linux install && cd - \
+    && wget https://luarocks.org/releases/luarocks-3.8.0.tar.gz && tar zxpf luarocks-3.8.0.tar.gz \
+    && cd luarocks-3.8.0 && ./configure && make && make install && cd -\
+    && export PATH=$PATH:/usr/local/bin/luarocks \
     && rm /tmp/kong.rpm \
     && chown kong:0 /usr/local/bin/kong \
     && chown -R kong:0 "$KONG_PREFIX" \

--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -36,7 +36,7 @@ RUN set -ex; \
     # Please update the ubuntu install docs if the below line is changed so that
     # end users can properly install Kong along with its required dependencies
     # and that our CI does not diverge from our docs.
-    && apt install --yes /tmp/kong.deb \
+    && apt install --yes /tmp/kong.deb luarocks\
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /tmp/kong.deb \
     && chown kong:0 /usr/local/bin/kong \


### PR DESCRIPTION
The error is simply due to the missing `luarocks-admin`, which requires installing `luarocks`.

`deb` and `rpm` packages need to be installed from source. Additionally, in the `rpm` environment, `lua-devel` and `readline-devel` cannot be directly installed using `yum`, so they also need to be installed from source.