### PR TITLE
[Feature] Dockerfile to run Kong on distroless image

### DIFF
--- a/ubuntu/distroless/Dockerfile
+++ b/ubuntu/distroless/Dockerfile
@@ -1,0 +1,140 @@
+#####################
+## Build stage
+#####################
+FROM ubuntu:jammy AS build
+LABEL maintainer="Kong Docker Maintainers <docker@konghq.com> (@team-gateway-bot)"
+
+ARG ASSET=ce
+ENV ASSET $ASSET
+
+ARG EE_PORTS
+
+COPY kong.deb /tmp/kong.deb
+
+ARG KONG_VERSION=3.7.1
+ENV KONG_VERSION $KONG_VERSION
+
+ARG KONG_AMD64_SHA="58e380961fc90c6b4dfd62f4ee596ab053afe5ae72a93445c4356f496f2dc9ec"
+ARG KONG_ARM64_SHA="602a68cf3a09bbea26106d4bd4041c242d7913e40582d18cac0f6958aad78f72"
+
+# hadolint ignore=DL3015
+RUN set -ex; \
+    arch=$(dpkg --print-architecture); \
+    case "${arch}" in \
+      amd64) KONG_SHA256=$KONG_AMD64_SHA ;; \
+      arm64) KONG_SHA256=$KONG_ARM64_SHA ;; \
+    esac; \
+    apt-get update \
+    && if [ "$ASSET" = "ce" ] ; then \
+      apt-get install -y --no-install-recommends curl ca-certificates \
+      && UBUNTU_CODENAME=$(cat /etc/os-release | grep UBUNTU_CODENAME | cut -d = -f 2) \
+      && KONG_REPO=$(echo ${KONG_VERSION%.*} | sed 's/\.//') \
+      && curl -fL https://packages.konghq.com/public/gateway-$KONG_REPO/deb/ubuntu/pool/$UBUNTU_CODENAME/main/k/ko/kong_$KONG_VERSION/kong_${KONG_VERSION}_$arch.deb -o /tmp/kong.deb \
+      && apt-get purge -y curl \
+      && echo "$KONG_SHA256  /tmp/kong.deb" | sha256sum -c - \
+      || exit 1; \
+    else \
+      # this needs to stay inside this "else" block so that it does not become part of the "official images" builds (https://github.com/docker-library/official-images/pull/11532#issuecomment-996219700)
+      apt-get upgrade -y ; \
+    fi; \
+    apt-get install -y --no-install-recommends unzip git \
+    # Please update the ubuntu install docs if the below line is changed so that
+    # end users can properly install Kong along with its required dependencies
+    # and that our CI does not diverge from our docs.
+    && apt install --yes --no-install-recommends /tmp/kong.deb \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -rf /tmp/kong.deb \
+    && chown kong:0 /usr/local/bin/kong \
+    && chown -R kong:0 /usr/local/kong \
+    && ln -sf /usr/local/openresty/bin/resty /usr/local/bin/resty \
+    && ln -sf /usr/local/openresty/luajit/bin/luajit /usr/local/bin/luajit \
+    && ln -sf /usr/local/openresty/luajit/bin/luajit /usr/local/bin/lua \
+    && ln -sf /usr/local/openresty/nginx/sbin/nginx /usr/local/bin/nginx \
+    && if [ "$ASSET" = "ce" ] ; then \
+      kong version ; \
+    fi
+
+#####################
+## Distroless stage
+#####################
+FROM  distroless-kong-base:0.0.1
+USER root
+
+WORKDIR /app
+
+# Add the kong user and group
+COPY <<EOF /etc/group
+root:x:0:
+kong:x:1000:
+nobody:x:1:
+nogroup:x:2:
+EOF
+
+COPY <<EOF /etc/passwd
+root:x:0:0:root:/root:/sbin/nologin
+kong:x:1000:1000:kong:/home/kong:/sbin/nologin
+nobody:x:1:1:nobody:/home/nobody:/sbin/nologin
+nogroup:x:2:2:nogroup:/home/nogroup:/sbin/nologin
+EOF
+
+
+# Copy necessary binaries and libraries from build stage
+COPY --from=build /usr/local/openresty/luajit/lib/libluajit-5.1.so.2 /usr/lib/x86_64-linux-gnu/
+COPY --from=build "/usr/lib/x86_64-linux-gnu/libstdc++.so.6" "/usr/lib/"
+COPY --from=build /lib32 /lib32/
+COPY --from=build /usr/local/bin/luajit /usr/local/bin/luajit
+COPY --from=build /usr/local/openresty/luajit/include/ /usr/local/openresty/luajit/include/
+COPY --from=build /usr/local/lib/luarocks /usr/local/lib/luarocks
+COPY --from=build /usr/local/openresty/luajit/lib /usr/local/openresty/luajit/lib
+COPY --from=build /usr/local/openresty/luajit/share /usr/local/openresty/luajit/share
+COPY --from=build /usr/local/lib/lua /usr/local/lib/lua
+COPY --from=build /usr/local/openresty/lualib/ /usr/local/openresty/lualib/
+COPY --from=build /usr/local/share/lua /usr/local/share/lua
+COPY --from=build /usr/local/share/lua/5.1 /usr/local/share/lua/5.1
+COPY --from=build /usr/lib/x86_64-linux-gnu/perl-base/ /usr/lib/
+COPY --from=build /usr/lib/x86_64-linux-gnu/ /usr/lib/x86_64-linux-gnu/
+COPY --from=build /lib/x86_64-linux-gnu/libtinfo.so.6 /lib/x86_64-linux-gnu/libtinfo.so.6
+COPY --from=build /lib/x86_64-linux-gnu/libdl.so.2 /lib/x86_64-linux-gnu/libdl.so.2
+COPY --from=build /lib/x86_64-linux-gnu/libc.so.6 /lib/x86_64-linux-gnu/libc.so.6
+COPY --from=build /lib64/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2
+
+
+# Copy Kong installation
+COPY --from=build /usr/local/kong /usr/local/kong
+COPY --from=build /usr/local/bin/kong /usr/local/bin/kong
+COPY --from=build /usr/local/bin/resty /usr/local/bin/resty
+COPY --from=build /usr/local/openresty/bin/resty /usr/local/openresty/bin/resty
+COPY --from=build /usr/local/bin/luajit /usr/local/bin/luajit 
+COPY --from=build /usr/local/openresty/luajit/bin/luajit /usr/local/openresty/luajit/bin/luajit 
+COPY --from=build /usr/local/openresty/nginx/ /usr/local/openresty/nginx/ 
+COPY --from=build /usr/local/bin/nginx /usr/local/bin/nginx
+COPY --from=build /usr/bin/env /usr/bin/env
+COPY --from=build /usr/bin/perl /usr/bin/perl
+COPY --from=build /usr/share/perl5 /usr/share/perl5
+COPY --from=build /lib/x86_64-linux-gnu/ /lib/x86_64-linux-gnu/
+COPY --from=build /usr/local/share/lua/5.1/ffi-zlib.lua /usr/local/share/lua/5.1/
+COPY --from=build /usr/local/lib/ /usr/local/lib/
+
+
+# Copy additional libraries and plugins
+# COPY plugins/ /opt/kong/plugins/
+# COPY libraries/ /opt/kong/lib/
+COPY --from=build /usr/lib/x86_64-linux-gnu/libhogweed* /usr/lib/
+
+# Apply core patches
+COPY --from=build /usr/local/share/lua/5.1/ /usr/local/share/lua/5.1/
+# Copy the entrypoint script
+COPY docker-entrypoint.sh /app/docker-entrypoint.sh
+
+
+ENTRYPOINT ["sh","/app/docker-entrypoint.sh"]
+
+EXPOSE 8000 8443 8001 8444 $EE_PORTS
+
+STOPSIGNAL SIGQUIT
+
+HEALTHCHECK --interval=60s --timeout=10s --retries=10 CMD kong-health
+
+CMD ["kong", "docker-start"]
+
+

--- a/ubuntu/distroless/base-dockerfile
+++ b/ubuntu/distroless/base-dockerfile
@@ -1,0 +1,67 @@
+ARG BUILDERIMAGE="busybox:1.36.1-uclibc"
+ARG BASEIMAGE="gcr.io/distroless/static-debian12"
+
+FROM $BUILDERIMAGE as binaries
+FROM $BUILDERIMAGE as builder
+
+ARG username=app
+ENV USERNAME $username
+
+ARG IMAGE_NAME="distroless-kong-base"
+
+ARG gid=2001
+ARG uid=1001
+
+ARG data_path=/app
+ENV DATA_PATH  $data_path
+
+ARG OMS_CLIENT_TENANT_DIR=/tenants-clients
+ENV OMS_CLIENT_TENANT_DIR $OMS_CLIENT_TENANT_DIR
+
+
+RUN addgroup -g $gid $USERNAME \
+      && adduser -DH -u $uid $USERNAME -G $USERNAME \
+      && mkdir -p $OMS_CLIENT_TENANT_DIR && chown $USERNAME:$USERNAME $OMS_CLIENT_TENANT_DIR \
+      && mkdir -p $DATA_PATH && chown $USERNAME:$USERNAME $DATA_PATH
+
+FROM $BASEIMAGE
+
+# default non-root gid and uid user
+ARG username=app
+ENV USERNAME $username
+
+ARG gid=2001
+ARG uid=1001
+
+# data_path is mostly for storing jars,binaries and other config files
+ARG data_path=/app
+ENV DATA_PATH  $data_path
+
+ARG TENANT_DIR=/tenants-clients
+ENV TENANT_DIR $TENANT_DIR
+
+#The following binaries will be available in the final image
+COPY --from=binaries /bin/cp /bin/cp
+COPY --from=binaries /bin/sh /bin/sh
+COPY --from=binaries /bin/ls /bin/ls
+COPY --from=binaries /bin/ash /bin/ash
+COPY --from=binaries /bin/echo /bin/echo
+COPY --from=binaries /bin/sha1sum /bin/sha1sum
+COPY --from=binaries /bin/grep /bin/grep
+COPY --from=binaries /bin/tr /bin/tr
+COPY --from=binaries /bin/sed /bin/sed
+COPY --from=binaries /bin/cat /bin/cat
+COPY --from=binaries /bin/hostname /bin/hostname
+COPY --from=binaries /bin/rm /bin/rm
+COPY --from=binaries /bin/ln /bin/ln
+
+
+COPY --from=builder /etc/passwd /etc/passwd
+COPY --from=builder /etc/group /etc/group
+COPY --from=builder --chown=$USERNAME:$USERNAME $TENANT_DIR $TENANT_DIR
+COPY --from=builder --chown=$USERNAME:$USERNAME $DATA_PATH $DATA_PATH
+
+WORKDIR $DATA_PATH
+
+# become rootless user
+USER $USERNAME:$USERNAME

--- a/ubuntu/distroless/docker-entrypoint.sh
+++ b/ubuntu/distroless/docker-entrypoint.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+set -Eeo pipefail
+
+# usage: file_env VAR [DEFAULT]
+#    ie: file_env 'XYZ_DB_PASSWORD' 'example'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
+# "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
+file_env() {
+  var="$1"
+  fileVar="${var}_FILE"
+  def="${2:-}"
+  # Do not continue if _FILE env is not set
+  eval "fileVarValue=\${${fileVar}}"
+  if [ -z "$fileVarValue" ]; then
+    return
+  fi
+  eval "varValue=\${${var}}"
+  if [ -n "$varValue" ] && [ -n "$fileVarValue" ]; then
+    echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
+    exit 1
+  fi
+  val="$def"
+  if [ -n "$varValue" ]; then
+    val="$varValue"
+  elif [ -n "$fileVarValue" ]; then
+    val="$(cat "$fileVarValue")"
+  fi
+  export "$var"="$val"
+  unset "$fileVar"
+}
+
+export KONG_NGINX_DAEMON=${KONG_NGINX_DAEMON:-off}
+
+if [ "$1" = "kong" ]; then
+
+  all_kong_options="/usr/local/share/lua/5.1/kong/templates/kong_defaults.lua"
+  set +Eeo pipefail
+  while IFS='' read -r LINE || [ -n "$LINE" ]; do
+      opt=$(echo "$LINE" | grep "=" | sed "s/=.*$//" | sed "s/ //" | tr '[:lower:]' '[:upper:]')
+      file_env "KONG_$opt"
+  done < "$all_kong_options"
+  set -Eeo pipefail
+
+  file_env KONG_PASSWORD
+  PREFIX=${KONG_PREFIX:-/usr/local/kong}
+
+  if [ "$2" = "docker-start" ]; then
+    kong prepare -p "$PREFIX" "$@"
+
+    ln -sf /dev/stdout "$PREFIX/logs/access.log"
+    ln -sf /dev/stdout "$PREFIX/logs/admin_access.log"
+    ln -sf /dev/stderr "$PREFIX/logs/error.log"
+
+    exec /usr/local/openresty/nginx/sbin/nginx \
+      -p "$PREFIX" \
+      -c nginx.conf
+  fi
+fi
+
+exec "$@"


### PR DESCRIPTION
Hi Community,

**Summary**:
This PR introduces a Dockerfile for running Kong on a distroless image.

**Details**:
- The builder image used is Ubuntu Jammy, consistent with the distro-ful Dockerfile.
- This setup has been tested on Kong versions `2.8.3` and `3.7.1.` A basic load test using K6s on local has been performed. Please share any specific testing suites that Kong follows for its releases, to ensure thorough validation.
- The Dockerfile's entrypoint has been changed from **bash** to **sh** to reduce dependencies and minimize the attack surface.


This PR resolves Issue #717, which can now be closed.