### PR TITLE
fix(docker-entrypoint): search new directory for socket cleanup

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -46,7 +46,7 @@ if [[ "$1" == "kong" ]]; then
 
     # remove all dangling sockets in $PREFIX dir before starting Kong
     LOGGED_SOCKET_WARNING=0
-    for localfile in "$PREFIX"/*; do
+    for localfile in "$PREFIX"/* "$PREFIX"/sockets/*; do
       if [ -S "$localfile" ]; then
         if (( LOGGED_SOCKET_WARNING == 0 )); then
           printf >&2 'WARN: found dangling unix sockets in the prefix directory '

--- a/ubuntu/docker-entrypoint.sh
+++ b/ubuntu/docker-entrypoint.sh
@@ -46,7 +46,7 @@ if [[ "$1" == "kong" ]]; then
 
     # remove all dangling sockets in $PREFIX dir before starting Kong
     LOGGED_SOCKET_WARNING=0
-    for localfile in "$PREFIX"/*; do
+    for localfile in "$PREFIX"/* "$PREFIX"/sockets/*; do
       if [ -S "$localfile" ]; then
         if (( LOGGED_SOCKET_WARNING == 0 )); then
           printf >&2 'WARN: found dangling unix sockets in the prefix directory '


### PR DESCRIPTION
This adapts the fix from d3411e0 to additionally search $PREFIX/sockets for leftover unix sockets.

See also: https://github.com/Kong/kong/pull/13409 and https://github.com/Kong/kong/issues/13730

[KAG-5691](https://konghq.atlassian.net/browse/KAG-5691)

[KAG-5691]: https://konghq.atlassian.net/browse/KAG-5691?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ