### PR TITLE
chore(deps): bump ubuntu from jammy to noble

### DIFF
--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:jammy
+FROM ubuntu:noble
 
 LABEL maintainer="Kong Docker Maintainers <docker@konghq.com> (@team-gateway-bot)"
 


### PR DESCRIPTION
Move Kong to latest ubuntu distro for CVE remediations around openssl and other security concerns.