### PR TITLE
ci(*): bump runner version to use the ubuntu-latest

### DIFF
--- a/.github/workflows/version2_test.yml
+++ b/.github/workflows/version2_test.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 jobs:
   test:
     name: Build & Test Version 2
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     timeout-minutes: 30
 
     strategy:


### PR DESCRIPTION
Bump the runner version to the `ubuntu-latest` as `ubuntu-20.04` is retired.

KAG-7154