### PR TITLE
fix(compose): add depends_on health checks for PostgreSQL

### DIFF
--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -29,7 +29,8 @@ services:
     command: kong migrations bootstrap
     profiles: [ "database" ]
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     environment:
       <<: *kong-env
     secrets:
@@ -43,7 +44,8 @@ services:
     command: kong migrations up && kong migrations finish
     profiles: [ "database" ]
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     environment:
       <<: *kong-env
     secrets:
@@ -55,6 +57,11 @@ services:
   kong:
     image: "${KONG_DOCKER_TAG:-kong:latest}"
     user: "${KONG_USER:-kong}"
+    depends_on:
+      db:
+        condition: service_healthy
+      kong-migrations:
+        condition: service_completed_successfully
     environment:
       <<: *kong-env
       KONG_ADMIN_ACCESS_LOG: /dev/stdout


### PR DESCRIPTION
## Summary

- Add `condition: service_healthy` to `depends_on` for `kong-migrations` and `kong-migrations-up` services so they wait for PostgreSQL to be healthy before running migrations
- Add `depends_on` to the `kong` service to wait for both the database (healthy) and migrations (completed) before starting

## Problem

When running `docker-compose --profile database up`, Kong starts before PostgreSQL is ready, causing connection errors:

```
init_by_lua error: [PostgreSQL error] failed to retrieve PostgreSQL server_version_num: connection refused
```

This requires a manual restart of the Kong container after PostgreSQL is ready.

## Test plan

- [ ] Run `docker-compose --profile database up` from a clean state
- [ ] Verify Kong starts successfully without needing a manual restart
- [ ] Verify `curl http://localhost:8001/` returns Kong's Admin API response

🤖 Generated with [Claude Code](https://claude.com/claude-code)